### PR TITLE
[JENKINS-37011] Allow StepDescriptor to define how single argument invocation gets handled

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.1</version>
+            <version>1.3-SNAPSHOT</version><!-- requires JENKINS-29922 fix -->
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/StepDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/StepDescriptor.java
@@ -26,19 +26,14 @@ package org.jenkinsci.plugins.workflow.steps;
 
 import hudson.ExtensionList;
 import hudson.model.Descriptor;
+import org.jenkinsci.plugins.structs.describable.DescribableModel;
+import org.jenkinsci.plugins.structs.describable.DescribableParameter;
 
+import javax.annotation.CheckForNull;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-
-import org.jenkinsci.plugins.structs.describable.DescribableModel;
-import org.jenkinsci.plugins.structs.describable.DescribableParameter;
-import org.kohsuke.stapler.ClassDescriptor;
-
-import javax.annotation.CheckForNull;
-
-import static com.sun.imageio.plugins.jpeg.JPEG.names;
 
 /**
  * {@link Descriptor} that provides information about {@link Step}.

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/StepDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/StepDescriptor.java
@@ -33,9 +33,12 @@ import java.util.Map;
 import java.util.Set;
 
 import org.jenkinsci.plugins.structs.describable.DescribableModel;
+import org.jenkinsci.plugins.structs.describable.DescribableParameter;
 import org.kohsuke.stapler.ClassDescriptor;
 
 import javax.annotation.CheckForNull;
+
+import static com.sun.imageio.plugins.jpeg.JPEG.names;
 
 /**
  * {@link Descriptor} that provides information about {@link Step}.
@@ -130,9 +133,9 @@ public abstract class StepDescriptor extends Descriptor<Step> {
      *      null if this step does not support the single argument form.
      */
     public @CheckForNull Map<String,Object> singleArgument(Object arg) {
-        String[] names = new ClassDescriptor(clazz).loadConstructorParamNames();
-        if (names.length == 1) {
-            return Collections.singletonMap(names[0], arg);
+        DescribableParameter p = new DescribableModel<>(clazz).getSoleRequiredParameter();
+        if (p!=null) {
+            return Collections.singletonMap(p.getName(), arg);
         } else {
             return null;
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/StepDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/StepDescriptor.java
@@ -33,8 +33,13 @@ import java.util.Map;
 import java.util.Set;
 
 import org.jenkinsci.plugins.structs.describable.DescribableModel;
+import org.kohsuke.stapler.ClassDescriptor;
+
+import javax.annotation.CheckForNull;
 
 /**
+ * {@link Descriptor} that provides information about {@link Step}.
+ *
  * @author Kohsuke Kawaguchi
  * @author Jesse Glick
  */
@@ -112,6 +117,25 @@ public abstract class StepDescriptor extends Descriptor<Step> {
      */
     public Map<String,Object> defineArguments(Step step) throws UnsupportedOperationException {
         return DescribableModel.uninstantiate_(step);
+    }
+
+    /**
+     * Some {@link Step} representation in text (such as Jenkins Pipeline) benefits from
+     * the short hand syntax that omits the explicit argument name when there's only one argument.
+     * This method provides that mechanism in which {@link StepDescriptor} can normalize
+     * such single value into a map that can then be fed into {@link #newInstance(Map)}.
+     *
+     * @return
+     *      map that assigns the name to the sole argument. Otherwise
+     *      null if this step does not support the single argument form.
+     */
+    public @CheckForNull Map<String,Object> singleArgument(Object arg) {
+        String[] names = new ClassDescriptor(clazz).loadConstructorParamNames();
+        if (names.length == 1) {
+            return Collections.singletonMap(names[0], arg);
+        } else {
+            return null;
+        }
     }
 
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/AbstractStepImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/AbstractStepImplTest.java
@@ -28,6 +28,9 @@ public class AbstractStepImplTest {
     @Inject
     BogusStep.DescriptorImpl d;
 
+    @Inject
+    OneArgStep.DescriptorImpl d2;
+
     @Before
     public void setUp() {
         j.getInstance().getInjector().injectMembers(this);
@@ -67,6 +70,14 @@ public class AbstractStepImplTest {
 
         assertEquals(step.a, 10);
         assertEquals(step.b, "pre1post");
+    }
+
+    @Test
+    public void singleArgument() throws Exception {
+        assertNull(d.singleArgument("foo"));    // require two arguments
+        Map<String, Object> m = d2.singleArgument("foo");
+        assertEquals(1,m.size());
+        assertEquals("a",m.keySet().iterator().next());
     }
 
     public static class BogusStep extends AbstractStepImpl {
@@ -117,6 +128,33 @@ public class AbstractStepImplTest {
             assertSame(jenkins, Jenkins.getInstance());
             assertSame(n, Jenkins.getInstance());
             return null;
+        }
+    }
+
+    public static class OneArgStep extends AbstractStepImpl {
+        String a;
+
+        @DataBoundConstructor
+        public OneArgStep(String a) {
+            this.a = a;
+        }
+
+        @Extension
+        public static class DescriptorImpl extends AbstractStepDescriptorImpl {
+
+            public DescriptorImpl() {
+                super(BogusStepExecution.class);
+            }
+
+            @Override
+            public String getFunctionName() {
+                return "xxx";
+            }
+
+            @Override
+            public String getDisplayName() {
+                return "yyy";
+            }
         }
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/AbstractStepImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/AbstractStepImplTest.java
@@ -4,6 +4,8 @@ import hudson.Extension;
 import hudson.model.Node;
 import jenkins.model.Jenkins;
 import org.codehaus.groovy.runtime.GStringImpl;
+
+import static java.util.Collections.singletonMap;
 import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.Rule;
@@ -13,6 +15,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
 import javax.inject.Inject;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -75,9 +78,7 @@ public class AbstractStepImplTest {
     @Test
     public void singleArgument() throws Exception {
         assertNull(d.singleArgument("foo"));    // require two arguments
-        Map<String, Object> m = d2.singleArgument("foo");
-        assertEquals(1,m.size());
-        assertEquals("a",m.keySet().iterator().next());
+        assertEquals(singletonMap("a","foo"), d2.singleArgument("foo"));
     }
 
     public static class BogusStep extends AbstractStepImpl {


### PR DESCRIPTION
Allow StepDescriptor to define how single argument invocation gets handled. This is necessary to properly support Steps that do not have `@DataBoundConstructor`
