### PR TITLE
Downgrade logging from getStatusBounded

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/StepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/StepExecution.java
@@ -139,7 +139,7 @@ public abstract class StepExecution implements Serializable {
             if (task != null) {
                 task.cancel(true); // in case of TimeoutException especially, we do not want this thread continuing
             }
-            LOGGER.log(Level.WARNING, "failed to check status of " + super.toString(), x);
+            LOGGER.log(Level.FINE, "failed to check status of " + super.toString(), x);
             return x.toString();
         }
     }


### PR DESCRIPTION
Looking at an actual log file where this is logged, there are dozens of stack traces like

```
… WARNING o.j.p.w.steps.StepExecution#getStatusBounded: failed to check status of org.jenkinsci.plugins.workflow.steps.durable_task.DurableTaskStep$Execution@…
java.util.concurrent.TimeoutException
	at java.util.concurrent.FutureTask.get(FutureTask.java:205)
	at org.jenkinsci.plugins.workflow.steps.StepExecution.getStatusBounded(StepExecution.java:135)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadDump$ThreadInfo.<init>(CpsThreadDump.java:49)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadDump$ThreadInfo.<init>(CpsThreadDump.java:29)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadDump.from(CpsThreadDump.java:139)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.getThreadDump(CpsThreadGroup.java:404)
	at org.jenkinsci.plugins.workflow.cps.CpsFlowExecution.getThreadDump(CpsFlowExecution.java:781)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadDumpAction$PipelineThreadDump$1.writeTo(CpsThreadDumpAction.java:77)
	at com.cloudbees.jenkins.support.SupportPlugin.writeBundle(SupportPlugin.java:358)
	at com.cloudbees.jenkins.support.SupportAction.doDownload(SupportAction.java:168)
	at …
```

which is not very informative. The virtual thread dump already notes the `TimeoutException`.

@reviewbybees