### PR TITLE
[JENKINS-41551] Do not call even getStatusBounded from toString

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/StepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/StepExecution.java
@@ -102,12 +102,6 @@ public abstract class StepExecution implements Serializable {
      */
     public void onResume() {}
 
-    @Override public String toString() {
-        String supe = super.toString();
-        String status = getStatusBounded(10, TimeUnit.MILLISECONDS);
-        return status != null ? supe + "(" + status + ")" : supe;
-    }
-
     /**
      * May be overridden to provide specific information about what a step is currently doing, for diagnostic purposes.
      * Typical format should be a short, lowercase phrase.


### PR DESCRIPTION
[JENKINS-41551](https://issues.jenkins-ci.org/browse/JENKINS-41551)

Related to, but distinct from, #16. Goes further than #12.

@reviewbybees