### PR TITLE
The parameter to argumentsToString should be @Nonnull

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/StepDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/StepDescriptor.java
@@ -321,8 +321,8 @@ public abstract class StepDescriptor extends Descriptor<Step> {
      * @return Formatted string, before escaping, or null if can't be converted easily to a String.
      */
     @CheckForNull
-    public String argumentsToString(@CheckForNull Map<String, Object> namedArgs) {
-        if (namedArgs != null && namedArgs.size() == 1) {
+    public String argumentsToString(@Nonnull Map<String, Object> namedArgs) {
+        if (namedArgs.size() == 1) {
             Object val = namedArgs.values().iterator().next();
             return (isAbleToUseToStringForDisplay(val)) ? val.toString() : null;
         }


### PR DESCRIPTION
It was a mistake to mark this `@CheckForNull` when in fact the only caller is `ArgumentsAction.getStepArgumentsAsString`, which calls it on a map which is never null. There is just no compelling reason why it would be null, and an extra null check imposes a burden on implementors.

(Ironically, prior to https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/47, the only override was [this one](https://github.com/jenkinsci/workflow-cps-plugin/blob/c69e3862bf26ac122dbc26345f1bb73b906c6824/src/test/java/org/jenkinsci/plugins/workflow/testMetaStep/MonomorphicStep.java#L60-L61), which assumed it was nonnull!)

@reviewbybees