### PR TITLE
Switch to POM properties for Pipeline-related dep versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,13 @@
     <properties>
         <jenkins.version>1.642.3</jenkins.version>
         <no-test-jar>false</no-test-jar>
+        <structs.version>1.5</structs.version>
+        <workflow-cps.version>2.23</workflow-cps.version>
+        <workflow-job.version>2.9</workflow-job.version>
+        <workflow-basic-steps.version>2.3</workflow-basic-steps.version>
+        <workflow-durable-task-step.version>2.5</workflow-durable-task-step.version>
+        <workflow-support.version>2.11</workflow-support.version>
+        <workflow-scm-step.version>2.3</workflow-scm-step.version>
     </properties>
     <dependencies>
         <dependency>
@@ -81,43 +88,43 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.5</version>
+            <version>${structs.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.23</version>
+            <version>${workflow-cps.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-job</artifactId>
-            <version>2.9</version>
+            <version>${workflow-job.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
-            <version>2.3</version>
+            <version>${workflow-basic-steps.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-durable-task-step</artifactId>
-            <version>2.5</version>
+            <version>${workflow-durable-task-step.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.11</version>
+            <version>${workflow-support.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-scm-step</artifactId>
-            <version>2.3</version>
+            <version>${workflow-scm-step.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
I'm working on tooling to do testing of core + groovy-sandbox +
groovy-cps + workflow-cps + script-security + the rest of the main
Pipeline plugins against bleeding-edge versions of each other and
different versions of Groovy. To do this, it'd be a lot easier if the
dependencies between the various things I'm building/testing had their
versions controlled by properties.

cc @reviewbybees 