### PR TITLE
StepDescriptor API to signal that we should allow the Execution to attach actions before persisting flownodes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-step-api</artifactId>
-    <version>2.13-deferactionwrite-SNAPSHOT</version>
+    <version>2.13-deferactionwrite2-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Pipeline: Step API</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Step+API+Plugin</url>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-step-api</artifactId>
-    <version>2.13-SNAPSHOT</version>
+    <version>2.13-deferactionwrite-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <name>Pipeline: Step API</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Step+API+Plugin</url>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/StepDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/StepDescriptor.java
@@ -96,17 +96,14 @@ public abstract class StepDescriptor extends Descriptor<Step> {
     public abstract String getFunctionName();
 
     /**
-     *  Test if we can defer persisting state around this {@link Step} for efficiency.
+     *  If true, we shouldn't write out the FlowNode or its actions until this step's {@link StepExecution} explicitly
+     *  re-enables persistence.
      *
-     *  <p><strong>Common uses:</strong>
-     *  <ul>
-     *      <li>Where the {@link StepExecution} adds multiple actions, defer persisting until done.</li>
-     *      <li>If we can simple run the Step again</li>
-     *  </ul>
-     *
-     *  @return True if we shouldn't write out state around this step until explicitly forced to.
+     *  This allows Steps that attach {@link hudson.model.Action}s to complete that before writing out the data,
+     *  avoiding redundant write-rewrite cycles and greatly boosting performance when running this {@link Step}
+     *  @return True if we shouldn't write out the FlowNode or its Actions around this step until explicitly forced to.
      */
-    public boolean deferWritingState() {
+    public boolean delayWritingFlownodeActions() {
         return false;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/StepDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/StepDescriptor.java
@@ -96,6 +96,21 @@ public abstract class StepDescriptor extends Descriptor<Step> {
     public abstract String getFunctionName();
 
     /**
+     *  Test if we can defer persisting state around this {@link Step} for efficiency.
+     *
+     *  <p><strong>Common uses:</strong>
+     *  <ul>
+     *      <li>Where the {@link StepExecution} adds multiple actions, defer persisting until done.</li>
+     *      <li>If we can simple run the Step again</li>
+     *  </ul>
+     *
+     *  @return True if we shouldn't write out state around this step until explicitly forced to.
+     */
+    public boolean deferWritingState() {
+        return false;
+    }
+
+    /**
      * Return true if this step can accept an implicit block argument.
      * (If it can, but it is called without a block, {@link StepContext#hasBody} will be false.)
      * @see StepContext#newBodyInvoker()


### PR DESCRIPTION
Detail TBD when other PRs are up to link to this one

For downstreams, deployed as: 

```
<dependency>
            <groupId>org.jenkins-ci.plugins.workflow</groupId>
            <artifactId>workflow-step-api</artifactId>
            <version>2.13-deferactionwrite2-20170901.210414-1</version>
        </dependency>
```
TODO:
- [ ] Show use by steps that attach a ton of actions