### PR TITLE
[JENKINS-48115] Don't include non-Describables as metasteps

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/StepDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/StepDescriptor.java
@@ -273,7 +273,20 @@ public abstract class StepDescriptor extends Descriptor<Step> {
             @SuppressFBWarnings(value="NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE", justification="all() will not return nulls")
             @Override
             public boolean apply(StepDescriptor i) {
-                return i.isMetaStep();
+                if (i.isMetaStep()) {
+                    Class<?> a = i.getMetaStepArgumentType();
+                    if (a != null) {
+                        if (Describable.class.isAssignableFrom(a)) {
+                            return true;
+                        } else {
+                            LOGGER.log(Level.WARNING,
+                                    "{0} claims to be a meta-step but has {1} instead of a Describable as the parameter in @DataBoundConstructor",
+                                    new Object[]{getClass().getName(), a.getName()});
+
+                        }
+                    }
+                }
+                return false;
             }
         });
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/StepDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/StepDescriptor.java
@@ -273,20 +273,19 @@ public abstract class StepDescriptor extends Descriptor<Step> {
             @SuppressFBWarnings(value="NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE", justification="all() will not return nulls")
             @Override
             public boolean apply(StepDescriptor i) {
-                if (i.isMetaStep()) {
-                    Class<?> a = i.getMetaStepArgumentType();
-                    if (a != null) {
-                        if (!a.equals(Object.class)) {
-                            return true;
-                        } else {
-                            LOGGER.log(Level.WARNING,
-                                    "{0} claims to be a meta-step but has {1} as the parameter in @DataBoundConstructor",
-                                    new Object[]{i.getClass().getName(), a.getName()});
-
-                        }
+                Class<?> a = i.getMetaStepArgumentType();
+                if (a != null) {
+                    if (a.equals(Object.class) || a.equals(Void.TYPE)) {
+                        LOGGER.log(Level.WARNING,
+                                "{0} claims to be a meta-step but has {1} as the parameter in @DataBoundConstructor",
+                                new Object[]{i.getClass().getName(), a.getName()});
+                        return false;
+                    } else {
+                        return true;
                     }
+                } else {
+                    return false;
                 }
-                return false;
             }
         });
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/StepDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/StepDescriptor.java
@@ -276,12 +276,12 @@ public abstract class StepDescriptor extends Descriptor<Step> {
                 if (i.isMetaStep()) {
                     Class<?> a = i.getMetaStepArgumentType();
                     if (a != null) {
-                        if (Describable.class.isAssignableFrom(a)) {
+                        if (!a.equals(Object.class)) {
                             return true;
                         } else {
                             LOGGER.log(Level.WARNING,
-                                    "{0} claims to be a meta-step but has {1} instead of a Describable as the parameter in @DataBoundConstructor",
-                                    new Object[]{getClass().getName(), a.getName()});
+                                    "{0} claims to be a meta-step but has {1} as the parameter in @DataBoundConstructor",
+                                    new Object[]{i.getClass().getName(), a.getName()});
 
                         }
                     }


### PR DESCRIPTION
[JENKINS-48115](https://issues.jenkins-ci.org/browse/JENKINS-48115)

While we can work around this in Declarative, cases like https://github.com/jenkinsci/jira-steps-plugin/blob/master/src/main/java/org/thoughtslive/jenkins/plugins/jira/steps/NewComponentStep.java#L50 end up reporting as metasteps of literally any existing symbol. So let's restrict `allMeta()` to only include steps with both `d.isMetaStep()==true` and `Describable.class.isAssignableFrom(d.getMetaStepArgumentType())`.

cc @reviewbybees 