### PR TITLE
SynchronousNonBlockingStepExecution.stop should call super

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/SynchronousNonBlockingStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/SynchronousNonBlockingStepExecution.java
@@ -22,6 +22,7 @@ public abstract class SynchronousNonBlockingStepExecution<T> extends StepExecuti
 
     private transient volatile Future<?> task;
     private transient String threadName;
+    private transient boolean stopping;
 
     private static ExecutorService executorService;
 
@@ -50,7 +51,9 @@ public abstract class SynchronousNonBlockingStepExecution<T> extends StepExecuti
                         }
                     }));
                 } catch (Throwable e) {
-                    getContext().onFailure(e);
+                    if (!stopping) {
+                        getContext().onFailure(e);
+                    }
                 }
             }
         });
@@ -63,8 +66,10 @@ public abstract class SynchronousNonBlockingStepExecution<T> extends StepExecuti
     @Override
     public void stop(Throwable cause) throws Exception {
         if (task != null) {
+            stopping = true;
             task.cancel(true);
         }
+        super.stop(cause);
     }
 
     @Override

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/SynchronousNonBlockingStepExecutionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/SynchronousNonBlockingStepExecutionTest.java
@@ -107,6 +107,10 @@ public class SynchronousNonBlockingStepExecutionTest {
         j.waitForMessage("Interrupted!", b);
         j.waitForCompletion(b);
         j.assertBuildStatus(Result.ABORTED, b);
+
+        // Also check that timeouts produce the right status.
+        p.setDefinition(new CpsFlowDefinition("timeout(time: 1, unit: 'SECONDS') {syncnonblocking 'wait2'}", true));
+        j.assertLogContains(new TimeoutStepExecution.ExceededTimeout().getShortDescription(), j.assertBuildStatus(Result.ABORTED, p.scheduleBuild2(0)));
     }
 
     @Test


### PR DESCRIPTION
…so that we properly handle `FlowInterruptedException`. Follows up #30 and works analogously to https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/50 and part of https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/67. Needed for https://github.com/jenkinsci/artifact-manager-s3-plugin/pull/41: otherwise,

```groovy
timeout(5) {
    archiveArtifacts '…'
}
```

will cause the build status to be `FAILURE` since an `InterruptedException` will be thrown and be treated as the terminal exception, while the `FlowInterruptedException` which captured the `ABORTED` status and reason for interruption is discarded.