### PR TITLE
 [JENKINS-49337] GeneralNonBlockingStepExecution

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.0-beta-3</version>
+    <version>1.0-beta-4</version>
   </extension>
 </extensions>

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(jenkinsVersions: [null, '2.32.2'])
+buildPlugin()

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.28</version>
+        <version>3.32</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
     <artifactId>workflow-step-api</artifactId>
-    <version>2.17-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <name>Pipeline: Step API</name>
     <url>https://wiki.jenkins-ci.org/display/JENKINS/Pipeline+Step+API+Plugin</url>
@@ -62,7 +62,7 @@
         </pluginRepository>
     </pluginRepositories>
     <properties>
-        <revision>2.16</revision>
+        <revision>2.17</revision>
         <changelist>-SNAPSHOT</changelist>
         <jenkins.version>2.60.3</jenkins.version>
         <java.level>8</java.level>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.12</version>
+        <version>3.28</version>
         <relativePath />
     </parent>
     <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -64,8 +64,8 @@
     <properties>
         <revision>2.16</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>1.642.3</jenkins.version>
-        <java.level>7</java.level>
+        <jenkins.version>2.60.3</jenkins.version>
+        <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
     </properties>
     <dependencies>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/BodyExecutionCallback.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/BodyExecutionCallback.java
@@ -104,6 +104,10 @@ public abstract class BodyExecutionCallback implements Serializable {
 
         /**
          * Called when the body is finished.
+         *
+         * <p>This method will run in the CPS VM thread and as such should not perform I/O or block.
+         * Use {@link GeneralNonBlockingStepExecution.TailCall} as needed.
+         *
          * @param context the body context as passed to {@link #onSuccess} or {@link #onFailure}
          * @throws Exception if anything is thrown here, the step fails too
          */

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/GeneralNonBlockingStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/GeneralNonBlockingStepExecution.java
@@ -33,7 +33,7 @@ import jenkins.model.Jenkins;
 import org.acegisecurity.Authentication;
 
 /**
- * Generalization of {@link SynchronousNonBlockingStepExecution} that can be used for block-scoped steps.
+ * Generalization of {@link SynchronousNonBlockingStepExecution} that can be used for {@linkplain StepDescriptor#takesImplicitBlockArgument block-scoped steps}.
  * The step may at any given time either be running CPS VM code, running background code,
  * or waiting for events (for example running a block).
  */

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/GeneralNonBlockingStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/GeneralNonBlockingStepExecution.java
@@ -1,0 +1,104 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.steps;
+
+import hudson.security.ACL;
+import hudson.security.ACLContext;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import javax.annotation.Nonnull;
+import jenkins.model.Jenkins;
+import org.acegisecurity.Authentication;
+
+/**
+ * Generalization of {@link SynchronousNonBlockingStepExecution} that can be used for block-scoped steps.
+ * The step may at any given time be running either CPS VM code, background code, or waiting for events (for example running a block).
+ */
+public abstract class GeneralNonBlockingStepExecution extends StepExecution {
+
+    private transient volatile Future<?> task;
+    private String threadName;
+    private transient boolean stopping;
+
+    protected GeneralNonBlockingStepExecution(StepContext context) {
+        super(context);
+    }
+
+    /**
+     * Initiate background work that should not block the CPS VM thread.
+     * Call this from a CPS VM thread, such as from {@link #start} or {@link BodyExecutionCallback#onSuccess}.
+     * The block may finish by calling {@link BodyInvoker#start}, {@link StepContext#onSuccess}, etc.
+     * @param block some code to run in a utility thread
+     */
+    protected final void run(Callable<Void> block) {
+        if (stopping) {
+            return;
+        }
+        final Authentication auth = Jenkins.getAuthentication();
+        task = SynchronousNonBlockingStepExecution.getExecutorService().submit(() -> {
+            threadName = Thread.currentThread().getName();
+            try {
+                try (ACLContext acl = ACL.as(auth)) {
+                    block.call();
+                }
+            } catch (Throwable e) {
+                if (!stopping) {
+                    getContext().onFailure(e);
+                }
+            } finally {
+                threadName = null;
+                task = null;
+            }
+        });
+    }
+
+    /**
+     * If the computation is going synchronously, try to cancel that.
+     */
+    @Override
+    public void stop(Throwable cause) throws Exception {
+        stopping = true;
+        if (task != null) {
+            task.cancel(true);
+        }
+        super.stop(cause);
+    }
+
+    @Override
+    public void onResume() {
+        if (threadName != null) {
+            getContext().onFailure(new Exception("Resume after a restart not supported while running background code"));
+        }
+    }
+
+    @Override public @Nonnull String getStatus() {
+        if (threadName != null) {
+            return "running in thread: " + threadName;
+        } else {
+            return "not currently scheduled, or running blocks";
+        }
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/GeneralNonBlockingStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/GeneralNonBlockingStepExecution.java
@@ -79,7 +79,7 @@ public abstract class GeneralNonBlockingStepExecution extends StepExecution {
             } catch (Throwable e) {
                 if (!stopping) {
                     getContext().onFailure(e);
-                }
+                } // TODO else perhaps call addSuppressed (same in TailCall.onSuccess)
             } finally {
                 threadName = null;
                 task = null;
@@ -133,7 +133,9 @@ public abstract class GeneralNonBlockingStepExecution extends StepExecution {
                 try {
                     finished(context);
                 } catch (Exception x) {
-                    context.onFailure(x);
+                    if (!stopping) {
+                        context.onFailure(x);
+                    }
                     return;
                 }
                 context.onSuccess(result);

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/GeneralNonBlockingStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/GeneralNonBlockingStepExecution.java
@@ -26,6 +26,7 @@ package org.jenkinsci.plugins.workflow.steps;
 
 import hudson.security.ACL;
 import hudson.security.ACLContext;
+import java.util.concurrent.Callable;
 import java.util.concurrent.Future;
 import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
@@ -33,7 +34,8 @@ import org.acegisecurity.Authentication;
 
 /**
  * Generalization of {@link SynchronousNonBlockingStepExecution} that can be used for block-scoped steps.
- * The step may at any given time be running either CPS VM code, background code, or waiting for events (for example running a block).
+ * The step may at any given time either be running CPS VM code, running background code,
+ * or waiting for events (for example running a block).
  */
 public abstract class GeneralNonBlockingStepExecution extends StepExecution {
 
@@ -47,6 +49,11 @@ public abstract class GeneralNonBlockingStepExecution extends StepExecution {
         super(context);
     }
 
+    /**
+     * Block to be passed to {@link #run}.
+     * like {@link Callable}{@code <}{@link Void}{@code >}, may throw an exception;
+     * yet like {@link Runnable}, it need not {@code return null;} at the end.
+     */
     @FunctionalInterface
     protected interface Block {
         void run() throws Exception;

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/GeneralNonBlockingStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/GeneralNonBlockingStepExecution.java
@@ -116,6 +116,10 @@ public abstract class GeneralNonBlockingStepExecution extends StepExecution {
         }
     }
 
+    @Override public boolean blocksRestart() {
+        return threadName != null;
+    }
+
     /**
      * Variant of {@link BodyExecutionCallback.TailCall} which wraps {@link #finished} in {@link #run}.
      */

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/MissingContextVariableException.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/MissingContextVariableException.java
@@ -18,12 +18,26 @@ public class MissingContextVariableException extends Exception {
     private final @Nonnull Class<?> type;
 
     public MissingContextVariableException(@Nonnull Class<?> type) {
-        super("Required context "+type+" is missing");
         this.type = type;
     }
 
     public Class<?> getType() {
         return type;
+    }
+
+    @Override public String getMessage() {
+        StringBuilder b = new StringBuilder("Required context ").append(type).append(" is missing");
+        boolean first = true;
+        for (StepDescriptor p : getProviders()) {
+            if (first) {
+                b.append("\nPerhaps you forgot to surround the code with a step that provides this, such as: ");
+                first = false;
+            } else {
+                b.append(", ");
+            }
+            b.append(p.getFunctionName());
+        }
+        return b.toString();
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/StepDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/StepDescriptor.java
@@ -99,6 +99,7 @@ public abstract class StepDescriptor extends Descriptor<Step> {
      * Return true if this step can accept an implicit block argument.
      * (If it can, but it is called without a block, {@link StepContext#hasBody} will be false.)
      * @see StepContext#newBodyInvoker()
+     * @see GeneralNonBlockingStepExecution
      */
     public boolean takesImplicitBlockArgument() {
         return false;

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/StepDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/StepDescriptor.java
@@ -310,7 +310,7 @@ public abstract class StepDescriptor extends Descriptor<Step> {
         List<StepDescriptor> r = new ArrayList<>();
         // honor ordinals among meta-steps
         for (StepDescriptor d : StepDescriptor.allMeta()) {
-            Class<?> a = d.getMetaStepArgumentType();
+            Class a = d.getMetaStepArgumentType();
             if (a==null)    continue;   // defensive check
             if (SymbolLookup.get().findDescriptor(a,symbol)!=null)
                 r.add(d);

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/StepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/StepExecution.java
@@ -15,6 +15,7 @@ import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.inject.Inject;
+import jenkins.model.queue.AsynchronousExecution;
 import jenkins.util.Timer;
 
 /**
@@ -124,6 +125,19 @@ public abstract class StepExecution implements Serializable {
      */
     public @CheckForNull String getStatus() {
         return null;
+    }
+
+    /**
+     * Allows a step to indicate that {@link AsynchronousExecution#blocksRestart} should be true.
+     * Typically this would be true if {@link #getStatus} indicates that the step is in the middle of something active,
+     * as opposed to waiting for an external event or a body to complete.
+     * <p>Note that activity in the CPS VM thread automatically blocks restart,
+     * so overriding this is only necessary for steps using a background thread,
+     * such as {@link SynchronousNonBlockingStepExecution} or {@link GeneralNonBlockingStepExecution}.
+     * @return false by default
+     */
+    public boolean blocksRestart() {
+        return false;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/StepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/StepExecution.java
@@ -60,7 +60,10 @@ public abstract class StepExecution implements Serializable {
     /**
      * Start execution of something and report the end result back to the given callback.
      *
-     * Arguments are passed when {@linkplain StepDescriptor#newInstance(Map) instantiating steps}.
+     * <p>Arguments are passed when {@linkplain StepDescriptor#newInstance(Map) instantiating steps}.
+     *
+     * <p>This method will run in the CPS VM thread and as such should not perform I/O or block.
+     * Use {@link SynchronousNonBlockingStepExecution} or {@link GeneralNonBlockingStepExecution} as needed.
      *
      * @return
      *      true if the execution of this step has synchronously completed before this method returns.

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/SynchronousNonBlockingStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/SynchronousNonBlockingStepExecution.java
@@ -1,16 +1,14 @@
 package org.jenkinsci.plugins.workflow.steps;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.security.ACL;
+import hudson.security.ACLContext;
 import hudson.util.DaemonThreadFactory;
 import hudson.util.NamingThreadFactory;
-
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
-import jenkins.security.NotReallyRoleSensitiveCallable;
 import org.acegisecurity.Authentication;
 
 /**
@@ -40,20 +38,17 @@ public abstract class SynchronousNonBlockingStepExecution<T> extends StepExecuti
     @Override
     public final boolean start() throws Exception {
         final Authentication auth = Jenkins.getAuthentication();
-        task = getExecutorService().submit(new Runnable() {
-            @SuppressFBWarnings(value="SE_BAD_FIELD", justification="not serializing anything here")
-            @Override public void run() {
-                try {
-                    getContext().onSuccess(ACL.impersonate(auth, new NotReallyRoleSensitiveCallable<T, Exception>() {
-                        @Override public T call() throws Exception {
-                            threadName = Thread.currentThread().getName();
-                            return SynchronousNonBlockingStepExecution.this.run();
-                        }
-                    }));
-                } catch (Throwable e) {
-                    if (!stopping) {
-                        getContext().onFailure(e);
-                    }
+        task = getExecutorService().submit(() -> {
+            threadName = Thread.currentThread().getName();
+            try {
+                T ret;
+                try (ACLContext acl = ACL.as(auth)) {
+                    ret = run();
+                }
+                getContext().onSuccess(ret);
+            } catch (Throwable e) {
+                if (!stopping) {
+                    getContext().onFailure(e);
                 }
             }
         });

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/SynchronousNonBlockingStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/SynchronousNonBlockingStepExecution.java
@@ -83,6 +83,10 @@ public abstract class SynchronousNonBlockingStepExecution<T> extends StepExecuti
         }
     }
 
+    @Override public boolean blocksRestart() {
+        return threadName != null;
+    }
+
     static synchronized ExecutorService getExecutorService() {
         if (executorService == null) {
             executorService = Executors.newCachedThreadPool(new NamingThreadFactory(new ClassLoaderSanityThreadFactory(new DaemonThreadFactory()), "org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution"));

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/GeneralNonBlockingStepExecutionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/GeneralNonBlockingStepExecutionTest.java
@@ -1,0 +1,126 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2018 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.steps;
+
+import hudson.model.TaskListener;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.Semaphore;
+import static org.hamcrest.Matchers.*;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowExecution;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
+import org.junit.ClassRule;
+import org.junit.Test;
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.jvnet.hudson.test.BuildWatcher;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class GeneralNonBlockingStepExecutionTest {
+
+    @ClassRule public static BuildWatcher buildWatcher = new BuildWatcher();
+
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @Test public void getStatus() throws Exception {
+        WorkflowJob p = r.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("slowBlock {semaphore 'wait'}", true));
+        WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+        startEnter.acquire();
+        assertThat(((CpsFlowExecution) b.getExecution()).getThreadDump().toString(), containsString("at DSL.slowBlock(running in thread: org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution [#1])"));
+        startExit.release();
+        SemaphoreStep.waitForStart("wait/1", b);
+        assertThat(((CpsFlowExecution) b.getExecution()).getThreadDump().toString(), containsString("at DSL.slowBlock(not currently scheduled, or running blocks)"));
+        SemaphoreStep.success("wait/1", null);
+        endEnter.acquire();
+        assertThat(((CpsFlowExecution) b.getExecution()).getThreadDump().toString(), containsString("at DSL.slowBlock(running in thread: org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution [#1])"));
+        endExit.release();
+        r.assertBuildStatusSuccess(r.waitForCompletion(b));
+    }
+
+    private static Semaphore startEnter, startExit, endEnter, endExit;
+
+    @Before public void semaphores() {
+        startEnter = new Semaphore(0);
+        startExit = new Semaphore(0);
+        endEnter = new Semaphore(0);
+        endExit = new Semaphore(0);
+    }
+
+    public static final class SlowBlockStep extends Step {
+        @DataBoundConstructor public SlowBlockStep() {}
+        @Override public StepExecution start(StepContext context) throws Exception {
+            return new Execution(context, this);
+        }
+        private static final class Execution extends GeneralNonBlockingStepExecution {
+            private final transient SlowBlockStep step;
+            Execution(StepContext context, SlowBlockStep step) {
+                super(context);
+                this.step = step;
+            }
+            private void println(String msg) throws Exception {
+                getContext().get(TaskListener.class).getLogger().println(msg);
+            }
+            @Override public boolean start() throws Exception {
+                println("starting step");
+                run(this::doStart);
+                return false;
+            }
+            private void doStart() throws Exception {
+                println("starting background part of step");
+                startEnter.release();
+                startExit.acquire();
+                println("starting body");
+                getContext().newBodyInvoker().withCallback(new Callback()).start();
+            }
+            private final class Callback extends TailCall {
+                @Override protected void finished(StepContext context) throws Exception {
+                    println("body completed, starting background end part of step");
+                    endEnter.release();
+                    endExit.acquire();
+                    println("ending step");
+                }
+            }
+        }
+        @TestExtension public static final class DescriptorImpl extends StepDescriptor {
+            @Override public String getFunctionName() {
+                return "slowBlock";
+            }
+            @Override public Set<? extends Class<?>> getRequiredContext() {
+                return Collections.singleton(TaskListener.class);
+            }
+            @Override public boolean takesImplicitBlockArgument() {
+                return true;
+            }
+        }
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/GeneralNonBlockingStepExecutionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/GeneralNonBlockingStepExecutionTest.java
@@ -61,7 +61,7 @@ public class GeneralNonBlockingStepExecutionTest {
         p.setDefinition(new CpsFlowDefinition("slowBlock {semaphore 'wait'}", true));
         WorkflowRun b = p.scheduleBuild2(0).waitForStart();
         startEnter.acquire();
-        assertThat(((CpsFlowExecution) b.getExecution()).getThreadDump().toString(), containsString("at DSL.slowBlock(running in thread: org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution [#1])"));
+        assertThat(((CpsFlowExecution) b.getExecution()).getThreadDump().toString(), containsString("at DSL.slowBlock(running in thread: org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution [#"));
         Thread.sleep(250); // give CPS thread some time to go back to sleep
         assertTrue(SynchronousNonBlockingStepExecutionTest.blocksRestart(b));
         startExit.release();
@@ -72,7 +72,7 @@ public class GeneralNonBlockingStepExecutionTest {
         }
         SemaphoreStep.success("wait/1", null);
         endEnter.acquire();
-        assertThat(((CpsFlowExecution) b.getExecution()).getThreadDump().toString(), containsString("at DSL.slowBlock(running in thread: org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution [#1])"));
+        assertThat(((CpsFlowExecution) b.getExecution()).getThreadDump().toString(), containsString("at DSL.slowBlock(running in thread: org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution [#"));
         Thread.sleep(250); // as above
         assertTrue(SynchronousNonBlockingStepExecutionTest.blocksRestart(b));
         endExit.release();


### PR DESCRIPTION
Utility to solve issues like [JENKINS-49337](https://issues.jenkins-ci.org/browse/JENKINS-49337).
- [x] local test coverage
- [X] example in `withCredentials` (when using file-based credentials that could potentially block in Remoting while setting up or tearing down): https://github.com/jenkinsci/credentials-binding-plugin/pull/53
- [X] example in `withMaven` (original motivation): https://github.com/jenkinsci/pipeline-maven-plugin/pull/199
- [X] example in `wrap` (actually much older): https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/78
- [X] example in `withDockerRegistry` / `withDockerServer`: https://github.com/jenkinsci/docker-workflow-plugin/pull/158
- [x] `CpsFlowExecution.blocksRestart` integration in https://github.com/jenkinsci/workflow-cps-plugin/pull/268