### PR TITLE
[JENKINS-53305] Use ClassLoaderSanityThreadFactory for SynchronousNonBlockingStepExecution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
         <jenkins.version>1.642.3</jenkins.version>
         <java.level>7</java.level>
         <no-test-jar>false</no-test-jar>
+        <workflow-support.version>2.11</workflow-support.version>
     </properties>
     <dependencies>
         <dependency>
@@ -113,7 +114,13 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-support</artifactId>
-            <version>2.11</version>
+            <version>${workflow-support.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-support</artifactId>
+            <version>${workflow-support.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/SynchronousNonBlockingStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/SynchronousNonBlockingStepExecution.java
@@ -8,6 +8,7 @@ import hudson.util.NamingThreadFactory;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
 import javax.annotation.Nonnull;
 import jenkins.model.Jenkins;
 import jenkins.security.NotReallyRoleSensitiveCallable;
@@ -87,9 +88,22 @@ public abstract class SynchronousNonBlockingStepExecution<T> extends StepExecuti
 
     static synchronized ExecutorService getExecutorService() {
         if (executorService == null) {
-            executorService = Executors.newCachedThreadPool(new NamingThreadFactory(new DaemonThreadFactory(), "org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution"));
+            executorService = Executors.newCachedThreadPool(new NamingThreadFactory(new ClassLoaderSanityThreadFactory(new DaemonThreadFactory()), "org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution"));
         }
         return executorService;
+    }
+
+    // TODO: When core baseline is 2.105+ delete and replace with hudson.util.ClassLoaderSanityThreadFactory.
+    private static class ClassLoaderSanityThreadFactory implements ThreadFactory {
+        private final ThreadFactory delegate;
+        public ClassLoaderSanityThreadFactory(ThreadFactory delegate) {
+            this.delegate = delegate;
+        }
+        public Thread newThread(Runnable r) {
+            Thread t = delegate.newThread(r);
+            t.setContextClassLoader(ClassLoaderSanityThreadFactory.class.getClassLoader());
+            return t;
+        }
     }
 
 }


### PR DESCRIPTION
See [JENKINS-53305](https://issues.jenkins-ci.org/browse/JENKINS-53305) and jenkinsci/workflow-basic-steps-plugin#69 for related discussion. 

This PR uses `ClassLoaderSanityThreadFactory` for `SynchronousNonBlockingStepExecution` so that the context class loader for all new threads is automatically set to the class loader for `ClassLoaderSanityThreadFactory`. If the root cause of the problem in JENKINS-53305 is that the class loader is somehow null coming into the step execution before we create a new thread in `SynchronousNonBlockingStepExecution`, then this would fix the problem.

If the root cause is instead that some code is incorrectly modifying the class loader inside of `SynchronousNonBlockingStepExecution#run`, then this would not fix the issue, as the threads in the pool may be reused and the fix only applies to newly created threads.

I am trying to work on adding some tracing to an instance where this problem occurs on occasion to understand the root cause, but I think this fix makes sense as a robustness improvement along the lines of jenkinsci/workflow-support-plugin#53 even if the root cause turns out to be bad code inside of a step.

@reviewbybees 