### PR TITLE
[JENKINS-55091] Let steps expose their result type

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/AbstractStepDescriptorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/AbstractStepDescriptorImpl.java
@@ -24,6 +24,7 @@ public abstract class AbstractStepDescriptorImpl extends StepDescriptor {
         this.executionType = executionType;
     }
 
+    @Override
     public final Class<? extends StepExecution> getExecutionType() {
         return executionType;
     }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/Step.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/Step.java
@@ -50,6 +50,8 @@ public abstract class Step extends AbstractDescribableImpl<Step> implements Exte
      *
      * Arguments are passed when {@linkplain StepDescriptor#newInstance instantiating steps}.
      *
+     * <p>Implementors should specify a more concrete return type (making use of return type covariance).</p>
+     *
      * @return
      *      true if the execution of this step has synchronously completed before this method returns.
      *      It is the callee's responsibility to set the return value via {@link StepContext#onSuccess(Object)}


### PR DESCRIPTION
Improve the type information provided by Pipeline steps. See [JENKINS-55091](https://issues.jenkins-ci.org/browse/JENKINS-55091). See also jenkinsci/workflow-cps-plugin#271.