### PR TITLE
Make {Synchronous,General}NonBlockingStepExecution.stopCause volatile

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/GeneralNonBlockingStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/GeneralNonBlockingStepExecution.java
@@ -43,7 +43,7 @@ public abstract class GeneralNonBlockingStepExecution extends StepExecution {
 
     private transient volatile Future<?> task;
     private String threadName;
-    private transient Throwable stopCause;
+    private transient volatile Throwable stopCause;
 
     protected GeneralNonBlockingStepExecution(StepContext context) {
         super(context);

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/SynchronousNonBlockingStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/SynchronousNonBlockingStepExecution.java
@@ -21,7 +21,7 @@ public abstract class SynchronousNonBlockingStepExecution<T> extends StepExecuti
 
     private transient volatile Future<?> task;
     private transient String threadName;
-    private transient Throwable stopCause;
+    private transient volatile Throwable stopCause;
 
     private static ExecutorService executorService;
 


### PR DESCRIPTION
Reasoning: stopCause is used from multiple threads. In order to guarantee that task thread sees updated value, JMM requires field to be volatile.