### PR TITLE
Make ExceptionCause public

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/ExceptionCause.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/ExceptionCause.java
@@ -12,7 +12,7 @@ import java.io.Serializable;
  * TODO: better summary.jelly
  * @author Kohsuke Kawaguchi
  */
-class ExceptionCause extends CauseOfInterruption implements Serializable {
+public class ExceptionCause extends CauseOfInterruption implements Serializable {
     private final Throwable t;
 
     public ExceptionCause(Throwable t) {


### PR DESCRIPTION
Useful to cleanly break from a retry wrapper, keeping the root exception:
```groovy
retry(50) {
  try {
    if(!ec2GetTags(instanceId).containsKey('slave_configuration')) {
      sleep 30
      throw new Exception('Missing tag slave_configuration on instance')
    }
  } catch (AmazonServiceException e) {
    throw new FlowInterruptedException(Result.FAILURE, new ExceptionCause(e) {})
  }
}
```