### PR TITLE
[JENKINS-58878] Add test that reproduces the issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,10 +64,10 @@
     <properties>
         <revision>2.21</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.121.1</jenkins.version>
+        <jenkins.version>2.138.4</jenkins.version>
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
-        <workflow-support.version>2.21</workflow-support.version>
+        <workflow-support.version>3.3</workflow-support.version>
     </properties>
     <dependencies>
         <dependency>
@@ -85,12 +85,12 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>structs</artifactId>
-            <version>1.18</version>
+            <version>1.20</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.62</version>
+            <version>2.76-rc2441.219abe39c1f0</version> <!-- TODO: See https://github.com/jenkinsci/workflow-cps-plugin/pull/335 -->
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-cps</artifactId>
-            <version>2.76-rc2441.219abe39c1f0</version> <!-- TODO: See https://github.com/jenkinsci/workflow-cps-plugin/pull/335 -->
+            <version>2.76</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/GeneralNonBlockingStepExecutionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/GeneralNonBlockingStepExecutionTest.java
@@ -119,13 +119,13 @@ public class GeneralNonBlockingStepExecutionTest {
     @Issue("JENKINS-58878")
     @Test public void shouldNotHang() throws Exception {
         int iterations = 50;
-        startExit = new Semaphore(iterations); // Prevents the semaphores from blocking inside of the slowBlock step.
-        endExit = new Semaphore(iterations);
+        startExit.release(iterations); // Prevents the semaphores from blocking inside of the slowBlock step.
+        endExit.release(iterations);
         WorkflowJob p = r.createProject(WorkflowJob.class);
         p.setDefinition(new CpsFlowDefinition(
                 "for (int i = 0; i < " + iterations + "; i++) {\n" +
                 "  slowBlock {\n" +
-                "    echo \"At ${i}\"\n" +
+                "    echo(/At $i/)\n" +
                 "  }\n" +
                 "}", true));
         r.buildAndAssertSuccess(p);

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/GeneralNonBlockingStepExecutionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/GeneralNonBlockingStepExecutionTest.java
@@ -41,7 +41,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import static org.junit.Assert.*;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.jvnet.hudson.test.BuildWatcher;
 import org.jvnet.hudson.test.Issue;
@@ -117,7 +116,6 @@ public class GeneralNonBlockingStepExecutionTest {
         assertThat(logging.getRecords(), empty());
     }
 
-    @Ignore
     @Issue("JENKINS-58878")
     @Test public void shouldNotHang() throws Exception {
         int iterations = 50;


### PR DESCRIPTION
See [JENKINS-58878](https://issues.jenkins-ci.org/browse/JENKINS-58878).

**Update**: fix is in https://github.com/jenkinsci/workflow-cps-plugin/pull/335, I'll update this PR once I have an incremental build.

---

Just adding an ignored test for now while I try to figure out the right way to fix the problem. Here's a bad fix:

```diff
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/GeneralNonBlockingStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/GeneralNonBlockingStepExecution.java
@@ -74,6 +74,7 @@ public abstract class GeneralNonBlockingStepExecution extends StepExecution {
             threadName = Thread.currentThread().getName();
             try {
                 try (ACLContext acl = ACL.as(auth)) {
+                    Thread.sleep(10L);
                     block.run();
                 }
             } catch (Throwable x) {
```

From playing with that fix, the sleep only seems to matter for starting the step. If you disable the sleep when `run` is called from `TailCall.onSuccess`, the test still passes. The test usually blocks for me pretty quickly (within 5 iterations of the loop), but I have seen it run as many as 40 iterations successfully.

One strange thing to me is that based on the log output, the completion callbacks appear to be running before the body executes. Here is the output of one of the hung tests:

```
   6.733 [test0 #1] Started
   7.930 [test0 #1] [Pipeline] slowBlock
   7.984 [test0 #1] starting step
   7.984 [test0 #1] starting background part of step
   7.984 [test0 #1] starting body
   7.985 [test0 #1] [Pipeline] {
   8.145 [test0 #1] body completed, starting background end part of step
   8.145 [test0 #1] ending step
   8.146 [test0 #1] [Pipeline] echo
   8.146 [test0 #1] At 0
   8.147 [test0 #1] [Pipeline] }
   8.199 [test0 #1] [Pipeline] // slowBlock
   8.254 [test0 #1] [Pipeline] slowBlock
   8.254 [test0 #1] starting step
   8.254 [test0 #1] starting background part of step
   8.254 [test0 #1] starting body
   8.255 [test0 #1] [Pipeline] {
   8.309 [test0 #1] body completed, starting background end part of step
   8.309 [test0 #1] ending step
   8.310 [test0 #1] [Pipeline] echo
   8.310 [test0 #1] At 1
   8.310 [test0 #1] [Pipeline] }
   8.311 [test0 #1] [Pipeline] // slowBlock
   8.311 [test0 #1] [Pipeline] slowBlock
   8.311 [test0 #1] starting step
   8.312 [test0 #1] starting background part of step
   8.312 [test0 #1] starting body
   8.364 [test0 #1] [Pipeline] {
   8.364 [test0 #1] body completed, starting background end part of step
   8.364 [test0 #1] ending step
   8.365 [test0 #1] [Pipeline] echo
   8.365 [test0 #1] At 2
   8.365 [test0 #1] [Pipeline] }
   8.417 [test0 #1] [Pipeline] // slowBlock
   8.418 [test0 #1] [Pipeline] slowBlock
   8.418 [test0 #1] starting step
   8.418 [test0 #1] starting background part of step
   8.418 [test0 #1] starting body
   8.419 [test0 #1] [Pipeline] {
   8.470 [test0 #1] body completed, starting background end part of step
   8.471 [test0 #1] ending step
   8.471 [test0 #1] [Pipeline] echo
   8.471 [test0 #1] At 3
   8.471 [test0 #1] [Pipeline] }
   8.472 [test0 #1] [Pipeline] // slowBlock
   8.523 [test0 #1] [Pipeline] slowBlock
   8.523 [test0 #1] starting step
   8.524 [test0 #1] starting background part of step
   8.524 [test0 #1] starting body
   8.525 [test0 #1] [Pipeline] {
   8.525 [test0 #1] body completed, starting background end part of step
   8.526 [test0 #1] ending step
   8.581 [test0 #1] [Pipeline] echo
   8.581 [test0 #1] At 4
   8.581 [test0 #1] [Pipeline] }
   8.582 [test0 #1] [Pipeline] // slowBlock
   8.582 [test0 #1] [Pipeline] slowBlock
   9.433 [test0 #1] starting step
   9.434 [test0 #1] starting background part of step
   9.435 [test0 #1] starting body
```