### PR TITLE
Migrate wiki content to GitHub and add 2.21 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,198 @@
+## Changelog
+
+### 2.21
+
+Release date: 2019-11-25
+
+-   Fix: Prevent potential concurrency issues that may have caused incorrect error reporting when attempting to cancel some kinds of steps more than once. ([PR 46](https://github.com/jenkinsci/workflow-step-api-plugin/pull/46))
+-   Developer: `DynamicContext` is now considered a stable API. ([PR 47](https://github.com/jenkinsci/workflow-step-api-plugin/pull/47))
+-   Internal: Add regression tests for [JENKINS-58878](https://issues.jenkins-ci.org/browse/JENKINS-58878). ([PR 49](https://github.com/jenkinsci/workflow-step-api-plugin/pull/49))
+-   Internal: Update parent POM. ([PR 45](https://github.com/jenkinsci/workflow-step-api-plugin/pull/45))
+
+### 2.20
+
+Release date: 2019-06-03
+
+-   [JENKINS-41854](https://issues.jenkins-ci.org/browse/JENKINS-41854) -
+    Add `DynamicContext` extension point that can be used to dynamically
+    inject and refresh Pipeline context variables.
+-   [PR #44](https://github.com/jenkinsci/workflow-step-api-plugin/pull/44) -
+    Improve how `FlowInterruptedExceptions` that contain
+    nested `FlowInterruptedExceptions` are displayed in build logs.
+-   [PR #43](https://github.com/jenkinsci/workflow-step-api-plugin/pull/43) -
+    Deprecate `StepDescriptor.newInstance` and `StepDescriptor.uninstantiate` in
+    favor of more general methods provided by `CustomDescribableModel`.
+
+### 2.19
+
+Release date: 2019-02-01
+
+Requires Jenkins core 2.121.1 or newer.
+
+-   [JENKINS-51170](https://issues.jenkins-ci.org/browse/JENKINS-51170) -
+    Add StepEnvironmentContributor extension point, which allows
+    extensions to access the current FlowNode when expanding environment
+    variables.
+-   Internal - Simplify test code by depending on a more recent version
+    of workflow-cps in test scope.
+
+### 2.18
+
+Release date: 2019-01-14
+
+-   [JENKINS-49337](https://issues.jenkins-ci.org/browse/JENKINS-49337) -
+    Add GeneralNonBlockingStepExecution utility to allow block-scope
+    steps to execute without blocking the CPS VM thread.
+
+### 2.17
+
+Release date: 2018-12-06
+
+-   Explicitly set the class loader used for worker threads created
+    by `SynchronousNonBlockingStepExecution` and its implementations to
+    avoid issues where the incorrect class loader was set on a worker
+    thread. May
+    fix [JENKINS-53305](https://issues.jenkins-ci.org/browse/JENKINS-53305),
+    but we have not been able to reproduce the issue in a test
+    environment to confirm.
+
+### 2.16
+
+Release date: 2018-06-25
+
+-   Update `SynchronousNonBlockingStepExecution.stop` to properly handle
+    `FlowInterruptedException`.
+
+### 2.15
+
+Release date: 2018-05-19
+
+-   Prevent silent hangs in `SynchronousNonBlockingStepExecution.run` by
+    catching and handling all `Throwables`
+-   Support Incrementals
+
+### 2.14
+
+Release date: 2017-11-21
+
+-   [JENKINS-48115](https://issues.jenkins-ci.org/browse/JENKINS-48115) -
+    Be defensive and don't include "metasteps" with `Object`
+    or `Void.Type` as their `metaStepArgumentType`, since that can end
+    up breaking many things.
+
+### 2.13
+
+Release date: 2017-09-19
+
+-   [JENKINS-26148](https://issues.jenkins-ci.org/browse/JENKINS-26148) -
+    Default implementation provided for `StepExecution.stop`
+
+### 2.12
+
+Release date: 2017-06-30
+
+-   The `StepDescriptor.argumentsToString` parameter need no longer be
+    checked for null.
+
+### 2.11
+
+Release date: 2017-06-05
+
+-   Added `EnvironmentExpander.constant` API.
+
+### 2.10
+
+Release date: 2017-05-22
+
+-   Feature: provide APIs to format Step arguments to Strings for UI
+    display - [JENKINS-37324](https://issues.jenkins-ci.org/browse/JENKINS-37324)
+-   Provide more legible stack traces
+
+### 2.9
+
+Release date: 2017-02-08
+
+-   Redundant recording of causes of interruption, affecting
+    [JENKINS-41276](https://issues.jenkins-ci.org/browse/JENKINS-41276)
+    fix.
+-   Excessive logging in virtual thread dumps; related to
+    [JENKINS-41551](https://issues.jenkins-ci.org/browse/JENKINS-41551)
+    fix.
+
+### 2.8
+
+Release date: 2017-02-02
+
+-   [JENKINS-41551](https://issues.jenkins-ci.org/browse/JENKINS-41551)
+    Fix a deadlock from calling `getStatusBounded` in
+    `StepExecution.toString`
+
+### 2.7
+
+Release date: 2017-01-10
+
+-   [JENKINS-40909](https://issues.jenkins-ci.org/browse/JENKINS-40909)
+    Enable steps formerly using `AbstractStepExecutionImpl`, which for
+    compatibility reasons must continue to do so, to compile without
+    deprecation warnings.
+
+### 2.6
+
+Release date: 2016-12-12
+
+-   [JENKINS-39134](https://issues.jenkins-ci.org/browse/JENKINS-39134)
+    Deprecating Guice-based step implementations as this system led to
+    various hard-to-debug problems. Issuing a runtime warning when one
+    such case can be detected.
+-   Making the test JAR smaller.
+
+### 2.5
+
+Release date: 2016-10-31
+
+-   [JENKINS-39275](https://issues.jenkins-ci.org/browse/JENKINS-39275)
+    Make sure diagnostics added in 2.2 do not block a thread
+    indefinitely.
+
+### 2.4
+
+Release date: 2016-09-23
+
+-   Error reporting improvement after build abort.
+
+### 2.3
+
+Release date: 2016-07-28
+
+-   Infrastructure for
+    [JENKINS-29922](https://issues.jenkins-ci.org/browse/JENKINS-29922).
+-   Record exceptions thrown during cleanup from a block step when the
+    block also failed.
+
+### 2.2
+
+Release date: 2016-06-29
+
+-   Infrastructure for
+    [JENKINS-31842](https://issues.jenkins-ci.org/browse/JENKINS-31842).
+
+### 2.1
+
+Release date: 2016-05-23
+
+-   API fix used in
+    [JENKINS-31831](https://issues.jenkins-ci.org/browse/JENKINS-31831).
+-   Javadoc correction used in
+    [JENKINS-26156](https://issues.jenkins-ci.org/browse/JENKINS-26156).
+-   API addition used in
+    [JENKINS-26107](https://issues.jenkins-ci.org/browse/JENKINS-26107).
+
+### 2.0
+
+Release date: 2016-04-05
+
+-   First release under per-plugin versioning scheme. See [1.x
+    changelog](https://github.com/jenkinsci/workflow-plugin/blob/82e7defa37c05c5f004f1ba01c93df61ea7868a5/CHANGES.md)
+    for earlier releases.
+-   Deprecated `DescribableHelper` in favor of the [Structs
+    plugin](https://plugins.jenkins.io/structs).

--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
-# Writing Pipeline steps
+# Pipeline: Step API Plugin
+
+[![Jenkins Plugin](https://img.shields.io/jenkins/plugin/v/workflow-step-api)](https://plugins.jenkins.io/workflow-step-api)
+[![Changelog](https://img.shields.io/github/v/tag/jenkinsci/workflow-step-api-plugin?label=changelog)](https://github.com/jenkinsci/workflow-step-api-plugin/blob/master/CHANGELOG.md)
+[![Jenkins Plugin Installs](https://img.shields.io/jenkins/plugin/i/workflow-step-api?color=blue)](https://plugins.jenkins.io/workflow-step-api)
+
+## Developer Guide: Writing Pipeline steps
 
 Plugins can implement custom Pipeline steps with specialized behavior by adding a dependency on `workflow-step-api`.
 Remember to ensure that your baseline Jenkins version is at least as new as that required by the versions of various Pipeline component plugins you are depending on.
 (The plugin wikis will note these baselines.)
 
-## Creating a basic synchronous step
+### Creating a basic synchronous step
 
 When a Pipeline step does something quick and nonblocking, you can make a “synchronous” step.
 The Groovy execution waits for it to finish.
@@ -34,7 +40,7 @@ This is still possible, but not recommended.
 If you must depend on an old version of `workflow-step-api`,
 *and* you are creating a non-blocking synchronous step, you will be obliged to use `AbstractStepImpl`, `AbstractStepDescriptorImpl`, `AbstractSynchronousNonBlockingStepExecution`, `@Inject`, and `@StepContextParameter`.
 
-## Creating an asynchronous step
+### Creating an asynchronous step
 
 For the more general case that a Pipeline step might block in network or disk I/O, and might need to survive Jenkins restarts, you can use a more powerful API.
 This relies on a callback system: the Pipeline engine tells your step when to start, and your step tells Pipeline when it is done.
@@ -62,7 +68,7 @@ getContext().onFailure(cause);
 
 but generally it will need to interrupt whatever process you started.
 
-## Creating a block-scoped step
+### Creating a block-scoped step
 
 Pipeline steps can also take “closures”: a code block which they may run zero or more times, optionally with some added context.
 
@@ -84,7 +90,10 @@ You can pass various contextual objects, as per `StepContext.get` above.
 
 `stop` is optional.
 
-## Using more APIs
+### Using more APIs
 
 You can also add a dependency on `workflow-api` which brings in more Pipeline-specific features.
 For example you can then receive a `FlowNode` from `StepContext.get` and call `addAction` to customize the _Pipeline Steps_ view.
+
+## Version history
+See [the changelog](CHANGELOG.md)

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <version>${revision}${changelist}</version>
     <packaging>hpi</packaging>
     <name>Pipeline: Step API</name>
-    <url>https://wiki.jenkins.io/display/JENKINS/Pipeline+Step+API+Plugin</url>
+    <url>https://github.com/jenkinsci/workflow-step-api-plugin</url>
     <licenses>
         <license>
             <name>MIT License</name>


### PR DESCRIPTION
I'd like to release this plugin today, so here is a PR to migrate the wiki content to GitHub so that the changelog can be updated for the release.