### PR TITLE
[JENKINS-60354] Add flag to FlowInterruptedException to indicate non-interruptions

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/FlowInterruptedException.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/FlowInterruptedException.java
@@ -62,8 +62,10 @@ public final class FlowInterruptedException extends InterruptedException {
      * If true, this exception represents an actual build interruption, rather than a general error with a result and
      * no stack trace.
      * Used by steps like {@code RetryStep} to decide whether to handle or rethrow a {@link FlowInterruptedException}.
+     * Non-null, except momentarily during deserialization before {@link #readResolve} sets the field to {@code true}
+     * for old instances serialized before this field was added.
      */
-    private final boolean actualInterruption;
+    private Boolean actualInterruption = true;
 
     /**
      * Creates a new exception.
@@ -73,7 +75,7 @@ public final class FlowInterruptedException extends InterruptedException {
     public FlowInterruptedException(@Nonnull Result result, @Nonnull CauseOfInterruption... causes) {
         this.result = result;
         this.causes = Arrays.asList(causes);
-        this.actualInterruption = false;
+        this.actualInterruption = true;
     }
 
     /**
@@ -98,6 +100,13 @@ public final class FlowInterruptedException extends InterruptedException {
 
     public boolean isActualInterruption() {
         return actualInterruption;
+    }
+
+    private Object readResolve() {
+        if (actualInterruption == null) {
+            actualInterruption = true;
+        }
+        return this;
     }
 
     /**


### PR DESCRIPTION
See [JENKINS-60354](https://issues.jenkins-ci.org/browse/JENKINS-60354).

Downstream PRs:

* https://github.com/jenkinsci/pipeline-build-step-plugin/pull/39
* https://github.com/jenkinsci/workflow-basic-steps-plugin/pull/102

### Problem

This PR and the linked tickets are trying to solve a problem introduced by https://github.com/jenkinsci/pipeline-build-step-plugin/pull/24 that caused failures of the `build` step to be treated like build interruptions by the `retry` step, so the build failure was ignored instead of being retried. This happened because the `build` step started using `FlowInterruptedException` so that it could propagate the exact result of the downstream job instead of always propagating `FAILURE`. `FlowInterruptedException` is used for things like manual build interruptions, and so some steps that catch exceptions, such as `retry`, have special behavior to rethrow this kind of exception.

### Fix

This chain of PRs tries to fix the issue by adding a flag to `FlowInterruptedException` that can be set to false to indicate that the exception should not be considered a build interruption, and that this type is only being used to track a specific build result. With this approach, we only need to change `build` to start setting this flag, and then steps like `retry` to examine this flag when choosing whether to handle or rethrow `FlowInterruptedException`.

### Potential Alternative Fix

I'm not super happy about reusing `FlowInterruptedException` for both interruptions and non-interruptions in this way. An alternative fix could be to introduce a new `HasResult` interface with a `getResult` method, maybe along with a `ShowStackTrace` marker interface, have `FlowInterruptedException` implement those interfaces. Then we'd update code that currently only uses `FlowInterruptedException` for its result to use the `HasResult` interface, and update things that use concrete types to decide whether to show stack traces check for the `ShowStackTrace` instead. We'd also introduce a new `PipelineResultException` that implements those interfaces, and then have `build` throw that exception instead of `FlowInterruptedException`. That would quite a bit more work though, and would be more complex, requiring changes in workflow-job and workflow-cps in areas involving build completion, so I'm inclined to stick with the simple approach for now.

