### PR TITLE
[JENKINS-63254][JENKINS-47101] add watch variables to EnvironmentExpander

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/EnvironmentExpander.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/EnvironmentExpander.java
@@ -53,11 +53,12 @@ public abstract class EnvironmentExpander implements Serializable {
     public abstract void expand(@Nonnull EnvVars env) throws IOException, InterruptedException;
 
     /**
-     * Override this method to allow tracking of sensitive environment variables
+     * Get the names of environment variables known to contain sensitive values, such as secrets, in the current context.
+     * Should be overridden by subclasses that bind secret values to environment variables.
      *
-     * @return the set of sensitive environment variable names to track.
+     * @return a set of environment variables known to contain sensitive values
      */
-    public Set<String> getSensitiveVars() {
+    public @Nonnull Set<String> getSensitiveVariables() {
         return Collections.emptySet();
     }
 
@@ -112,9 +113,9 @@ public abstract class EnvironmentExpander implements Serializable {
         }
 
         @Override
-        public Set<String> getSensitiveVars() {
-            Set<String> originalSensitive = original.getSensitiveVars();
-            Set<String> subsequentSensitive = subsequent.getSensitiveVars();
+        public Set<String> getSensitiveVariables() {
+            Set<String> originalSensitive = original.getSensitiveVariables();
+            Set<String> subsequentSensitive = subsequent.getSensitiveVariables();
             if (originalSensitive.isEmpty() && subsequentSensitive.isEmpty()) {
                 return Collections.emptySet();
             } else {

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/EnvironmentExpander.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/EnvironmentExpander.java
@@ -52,7 +52,12 @@ public abstract class EnvironmentExpander implements Serializable {
      */
     public abstract void expand(@Nonnull EnvVars env) throws IOException, InterruptedException;
 
-    public Set<String> getWatchedVars() {
+    /**
+     * Override this method to allow tracking of sensitive environment variables
+     *
+     * @return the set of sensitive environment variable names to track.
+     */
+    public Set<String> getSensitiveVars() {
         return Collections.emptySet();
     }
 
@@ -107,15 +112,15 @@ public abstract class EnvironmentExpander implements Serializable {
         }
 
         @Override
-        public Set<String> getWatchedVars() {
-            Set<String> origWatch = original.getWatchedVars();
-            Set<String> subWatch = subsequent.getWatchedVars();
-            if (origWatch.isEmpty() && subWatch.isEmpty()) {
+        public Set<String> getSensitiveVars() {
+            Set<String> originalSensitive = original.getSensitiveVars();
+            Set<String> subsequentSensitive = subsequent.getSensitiveVars();
+            if (originalSensitive.isEmpty() && subsequentSensitive.isEmpty()) {
                 return Collections.emptySet();
             } else {
                 Set<String> mergedWatch = new HashSet<>();
-                mergedWatch.addAll(origWatch);
-                mergedWatch.addAll(subWatch);
+                mergedWatch.addAll(originalSensitive);
+                mergedWatch.addAll(subsequentSensitive);
                 return mergedWatch;
             }
         }


### PR DESCRIPTION
[JENKINS-63254](https://issues.jenkins-ci.org/browse/JENKINS-63254)

Enable `EnvironmentExpander` to track sensitive variables

Upstream of:
https://github.com/jenkinsci/credentials-binding-plugin/pull/105
https://github.com/jenkinsci/workflow-cps-plugin/pull/370

cc @dwnusbaum @bitwiseman 