### PR TITLE
Incorrectly written BodyExecutionCallback implementations lead to zombie executions

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/BodyExecutionCallbackITest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/BodyExecutionCallbackITest.java
@@ -1,0 +1,90 @@
+package org.jenkinsci.plugins.workflow.steps;
+
+import hudson.model.Result;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.TestExtension;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.util.Collections;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class BodyExecutionCallbackITest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void unhandledAssertionsShouldNotCreateZombieExecutions() throws Exception {
+        j.jenkins.setNumExecutors(1);
+        WorkflowJob job = j.createProject(WorkflowJob.class);
+        job.setDefinition(new CpsFlowDefinition("node('master') { withStartFailure { echo 'oh dear' } }"));
+        j.buildAndAssertStatus(Result.FAILURE, job);
+        assertThat(j.jenkins.getComputers()[0].getExecutors().get(0).getCurrentWorkUnit(), nullValue());
+    }
+
+    public static class WithStartFailureStep extends Step {
+
+        @DataBoundConstructor
+        public WithStartFailureStep() {}
+
+        @TestExtension("unhandledAssertionsShouldNotCreateZombieExecutions")
+        public static class DescriptorImpl extends StepDescriptor {
+            @Override
+            public String getFunctionName() {
+                return "withStartFailure";
+            }
+
+            @Override
+            public Set<? extends Class<?>> getRequiredContext() {
+                return Collections.emptySet();
+            }
+
+            @Override
+            public boolean takesImplicitBlockArgument() {
+                return true;
+            }
+        }
+
+        @Override
+        public StepExecution start(StepContext context) throws Exception {
+            return new WithStartFailureStepExecution(context);
+        }
+
+        static class WithStartFailureStepExecution extends AbstractStepExecutionImpl {
+
+            WithStartFailureStepExecution(final StepContext context) {
+                super(context);
+            }
+
+            @Override
+            public boolean start() throws Exception {
+                getContext().newBodyInvoker().withCallback(new WithStartFailureStepCallback()).start();
+                return false;
+            }
+
+            static class WithStartFailureStepCallback extends BodyExecutionCallback {
+                @Override
+                public void onStart(StepContext context) {
+                    throw new RuntimeException("onStart broken");
+                }
+
+                @Override
+                public void onSuccess(StepContext context, Object result) {
+                    context.onSuccess(result);
+                }
+
+                @Override
+                public void onFailure(StepContext context, Throwable t) {
+                    context.onFailure(t);
+                }
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
I'm raising this PR as a minimal reproduction of the issue I noticed from a bug in the `withChecks` step of the `checks-api` plugin: https://github.com/jenkinsci/checks-api-plugin/pull/83

The `withChecks` step does not handle all possible exceptions in `onStart`, `onSuccess`, and `onFailure`. If an exception gets thrown by one of these methods, while the job appears to fail correctly, the executor on which the step is running does not, and you end up with a execution that must be killed manually.

Whilst it is obviously the responsibility of the plugin to behave correctly, this failure mode is particularly pernicious. If you run a jenkins instance with on-demand cloud agents then any zombie executions will prevent that cloud agent from being shut down until you manually kill it. I have seen three day old zombies on Monday morning from an executor that was unnecessarily up all weekend.

This PR does not (yet) contain a fix as I haven't looked into the plumbing of how this actually works. If someone can quickly identify the quick fix for this then that would be greatly appreciated, otherwise I will put on my spelunking gear.