### PR TITLE
[JENKINS-51454] Pipeline retry operation doesn't retry when there is a timeout inside of it

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/BodyExecutionCallback.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/BodyExecutionCallback.java
@@ -123,7 +123,7 @@ public abstract class BodyExecutionCallback implements Serializable {
             context.onSuccess(result);
         }
 
-        @Override public final void onFailure(StepContext context, Throwable t) {
+        @Override public void onFailure(StepContext context, Throwable t) {
             try {
                 finished(context);
             } catch (Exception x) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/FlowInterruptedException.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/FlowInterruptedException.java
@@ -102,6 +102,10 @@ public final class FlowInterruptedException extends InterruptedException {
         return actualInterruption;
     }
 
+    public void setActualInterruption(boolean actualInterruption) {
+        this.actualInterruption = actualInterruption;
+    }
+
     private Object readResolve() {
         if (actualInterruption == null) {
             actualInterruption = true;


### PR DESCRIPTION
See [JENKINS-51454](https://issues.jenkins.io/browse/JENKINS-51454). Upstream of jenkinsci/workflow-basic-steps-plugin#144.