### PR TITLE
Reduce usages of Guava

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/FlowInterruptedException.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/FlowInterruptedException.java
@@ -24,7 +24,6 @@
 
 package org.jenkinsci.plugins.workflow.steps;
 
-import com.google.common.collect.Sets;
 import hudson.AbortException;
 import hudson.Functions;
 import hudson.model.Executor;
@@ -121,7 +120,8 @@ public final class FlowInterruptedException extends InterruptedException {
         for (InterruptedBuildAction a : run.getActions(InterruptedBuildAction.class)) {
             boundCauses.addAll(a.getCauses());
         }
-        Collection<CauseOfInterruption> diff = Sets.difference(new LinkedHashSet<>(causes), boundCauses);
+        Set<CauseOfInterruption> diff = new LinkedHashSet<>(causes);
+        diff.removeAll(boundCauses);
         if (!diff.isEmpty()) {
             run.addAction(new InterruptedBuildAction(diff));
             for (CauseOfInterruption cause : diff) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/StepDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/StepDescriptor.java
@@ -65,7 +65,7 @@ public abstract class StepDescriptor extends Descriptor<Step> {
      * if your step cannot trivially handle a null value of a given kind, list that type here.
      * The Pipeline execution engine will then signal a user error before even starting your step if called in an inappropriate context.
      * For example, a step requesting a {@link Launcher} may only be run inside a {@code node {…}} block.
-     * @return typically a {@link Collections#unmodifiableSet(Set)} with context types like {@link TaskListener} or {@link Run} or {@link FilePath}
+     * @return a set of context types like {@link TaskListener} or {@link Run} or {@link FilePath}
      */
     public abstract Set<? extends Class<?>> getRequiredContext();
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/StepDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/StepDescriptor.java
@@ -25,7 +25,6 @@
 package org.jenkinsci.plugins.workflow.steps;
 
 import com.google.common.base.Predicate;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.ExtensionList;
@@ -66,7 +65,7 @@ public abstract class StepDescriptor extends Descriptor<Step> {
      * if your step cannot trivially handle a null value of a given kind, list that type here.
      * The Pipeline execution engine will then signal a user error before even starting your step if called in an inappropriate context.
      * For example, a step requesting a {@link Launcher} may only be run inside a {@code node {…}} block.
-     * @return typically an {@link ImmutableSet#of(Object)} with context types like {@link TaskListener} or {@link Run} or {@link FilePath}
+     * @return typically a {@link Collections#unmodifiableSet(Set)} with context types like {@link TaskListener} or {@link Run} or {@link FilePath}
      */
     public abstract Set<? extends Class<?>> getRequiredContext();
 


### PR DESCRIPTION
Reduce two unnecessary usages of Guava by replacing them with native Java Platform functionality. This is intended to be a very small and non-controversial change, since it only changes an internal implementation detail and API documentation without breaking compatibility.