### PR TITLE
`DynamicContext.Typed` did not correctly handle queries of subtypes

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/DynamicContext.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/DynamicContext.java
@@ -89,9 +89,17 @@ public interface DynamicContext extends ExtensionPoint {
          */
         protected abstract @CheckForNull T get(DelegatedContext context) throws IOException, InterruptedException;
 
-        @Override public final <T> T get(Class<T> key, DelegatedContext context) throws IOException, InterruptedException {
-            if (key.isAssignableFrom(type())) {
+        @Override public final <U> U get(Class<U> key, DelegatedContext context) throws IOException, InterruptedException {
+            Class<T> type = type();
+            if (key.isAssignableFrom(type)) {
                 return key.cast(get(context));
+            } else if (type.isAssignableFrom(key)) {
+                T t = get(context);
+                if (key.isInstance(t)) {
+                    return key.cast(t);
+                } else {
+                    return null;
+                }
             } else {
                 return null;
             }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/DynamicContextTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/DynamicContextTest.java
@@ -48,10 +48,10 @@ public class DynamicContextTest {
             }
         }
         DynamicContext ctx = new Dyn();
-        assertNotNull("can look up via superclass", ctx.get(Super.class, nullContext));
-        assertNotNull("can look up via subclass", ctx.get(Sub.class, nullContext));
-        assertNull("but not via an unrelated subclass", ctx.get(Sub2.class, nullContext));
-        assertNull("nor via an unrelated superclass", ctx.get(Runnable.class, nullContext));
+        assertNotNull("can look up via supertype", ctx.get(Super.class, nullContext));
+        assertNotNull("can look up via subtype", ctx.get(Sub.class, nullContext));
+        assertNull("but not via a mismatched subtype", ctx.get(Sub2.class, nullContext));
+        assertNull("nor via an unrelated supertype", ctx.get(Runnable.class, nullContext));
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/DynamicContextTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/DynamicContextTest.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2021 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.steps;
+
+import java.io.IOException;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class DynamicContextTest {
+
+    @Test public void subclassing() throws Exception {
+        class Super {}
+        class Sub extends Super {}
+        DynamicContext.DelegatedContext nullContext = new DynamicContext.DelegatedContext() {
+            @Override public <T> T get(Class<T> key) throws IOException, InterruptedException {
+                return null;
+            }
+        };
+        class Dyn extends DynamicContext.Typed<Super> {
+            @Override protected Class<Super> type() {
+                return Super.class;
+            }
+            @Override protected Super get(DelegatedContext context) {
+                return new Sub();
+            }
+        }
+        DynamicContext ctx = new Dyn();
+        assertNotNull("can look up via superclass", ctx.get(Super.class, nullContext));
+        assertNotNull("can look up via subclass", ctx.get(Sub.class, nullContext));
+    }
+
+}

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/DynamicContextTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/DynamicContextTest.java
@@ -33,6 +33,7 @@ public class DynamicContextTest {
     @Test public void subclassing() throws Exception {
         class Super {}
         class Sub extends Super {}
+        class Sub2 extends Super {}
         DynamicContext.DelegatedContext nullContext = new DynamicContext.DelegatedContext() {
             @Override public <T> T get(Class<T> key) throws IOException, InterruptedException {
                 return null;
@@ -49,6 +50,8 @@ public class DynamicContextTest {
         DynamicContext ctx = new Dyn();
         assertNotNull("can look up via superclass", ctx.get(Super.class, nullContext));
         assertNotNull("can look up via subclass", ctx.get(Sub.class, nullContext));
+        assertNull("but not via an unrelated subclass", ctx.get(Sub2.class, nullContext));
+        assertNull("nor via an unrelated superclass", ctx.get(Runnable.class, nullContext));
     }
 
 }


### PR DESCRIPTION
I traced some test failures in https://github.com/jenkinsci/kubernetes-plugin/pull/1083 to the fact that https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/180 serves `Computer` instances via `DynamicContext` for the first time, and `SecretsMasker` looks up `KubernetesComputer` rather than `Computer`. This was failing because `context.get(KubernetesComputer.class)` was `null` even when `context.get(Computer.class)` would have returned an instance of `KubernetesComputer`.
