### PR TITLE
`SynchronousResumeNotSupportedException` as a marker for lack of JENKINS-30383

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/AbstractSynchronousNonBlockingStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/AbstractSynchronousNonBlockingStepExecution.java
@@ -67,7 +67,7 @@ public abstract class AbstractSynchronousNonBlockingStepExecution<T> extends Abs
 
     @Override
     public void onResume() {
-        getContext().onFailure(new Exception("Resume after a restart not supported for non-blocking synchronous steps"));
+        getContext().onFailure(new SynchronousResumeNotSupportedException());
     }
 
     @Override public @Nonnull String getStatus() {

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/GeneralNonBlockingStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/GeneralNonBlockingStepExecution.java
@@ -104,7 +104,7 @@ public abstract class GeneralNonBlockingStepExecution extends StepExecution {
     @Override
     public void onResume() {
         if (threadName != null) {
-            getContext().onFailure(new Exception("Resume after a restart not supported while running background code"));
+            getContext().onFailure(new SynchronousResumeNotSupportedException());
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/StepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/StepExecution.java
@@ -112,6 +112,8 @@ public abstract class StepExecution implements Serializable {
     /**
      * Called when {@link StepExecution} is brought back into memory after restart.
      * Convenient for re-establishing the polling.
+     * <p>Currently not permitted to throw exceptions, but may report errors via {@link StepContext#onFailure}.
+     * @see SynchronousResumeNotSupportedException
      */
     public void onResume() {}
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/SynchronousNonBlockingStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/SynchronousNonBlockingStepExecution.java
@@ -72,7 +72,7 @@ public abstract class SynchronousNonBlockingStepExecution<T> extends StepExecuti
 
     @Override
     public void onResume() {
-        getContext().onFailure(new Exception("Resume after a restart not supported for non-blocking synchronous steps"));
+        getContext().onFailure(new SynchronousResumeNotSupportedException());
     }
 
     @Override public @Nonnull String getStatus() {

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/SynchronousResumeNotSupportedException.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/SynchronousResumeNotSupportedException.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2021 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.steps;
+
+/**
+ * May be reported from {@link StepExecution#onResume} when the step does not support resumption.
+ * Thrown by default from {@link SynchronousNonBlockingStepExecution},
+ * as well as from {@link GeneralNonBlockingStepExecution} when running step code rather than a block.
+ * ({@link SynchronousStepExecution} does not even bother implementing this method
+ * since it should never be listed as in progress to begin with.)
+ */
+public class SynchronousResumeNotSupportedException extends Exception {
+
+    public SynchronousResumeNotSupportedException() {
+        super("Resume after a restart not supported for non-blocking synchronous steps");
+    }
+
+}


### PR DESCRIPTION
Not solving https://issues.jenkins.io/browse/JENKINS-30383 as stated, but offering a well-typed marker that https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/180 could use to retry the entire enclosing `node` block when a synchronous step fails. This is coarser-grained and so less efficient, but might be safer in case a half-completed synchronous step left behind corrupt files or something; does not preclude a future option to directly retry the one step if it is known to be idempotent.
