### PR TITLE
Allow `AbstractStepImpl` to still be subclassed for serial compatibility

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,4 @@
 buildPlugin(useContainerAgent: true, configurations: [
-  [ platform: "linux", jdk: "8" ],
   [ platform: "windows", jdk: "8" ],
   [ platform: "linux", jdk: "11" ]
 ])

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/AbstractStepImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/AbstractStepImpl.java
@@ -10,13 +10,28 @@ import javax.inject.Inject;
  * Partial convenient step implementation.
  * Used with {@link AbstractStepDescriptorImpl} and {@link AbstractStepExecutionImpl}.
  * @author Kohsuke Kawaguchi
- * @deprecated Directly extend {@link Step} and avoid Guice.
  */
-@Deprecated
 public abstract class AbstractStepImpl extends Step {
 
+    /**
+     * @deprecated Directly extend {@link Step} and avoid Guice.
+     * Or see {@link #AbstractStepImpl(boolean)} for an existing step.
+     */
+    @Deprecated
+    protected AbstractStepImpl() {}
+
+    /**
+     * Constructor for compatibility.
+     * Retain this constructor and override {@link #start} if your step historically extended {@link AbstractStepImpl},
+     * and your {@link AbstractStepExecutionImpl} kept a non-{@code transient} reference to the {@link AbstractStepImpl},
+     * for serial form compatibility.
+     * For new steps, extend {@link Step} directly.
+     * @param ignored ignored, just to differentiate this constructor from {@link #AbstractStepImpl()} as a marker that the supertype must be retained
+     */
+    protected AbstractStepImpl(boolean ignored) {}
+
     /** Constructs a step execution automatically according to {@link AbstractStepDescriptorImpl#getExecutionType}. */
-    @Override public final StepExecution start(StepContext context) throws Exception {
+    @Override public StepExecution start(StepContext context) throws Exception {
         AbstractStepDescriptorImpl d = (AbstractStepDescriptorImpl) getDescriptor();
         return prepareInjector(context, this).getInstance(d.getExecutionType());
     }


### PR DESCRIPTION
Similar to #17. https://github.com/jenkinsci/pipeline-input-step-plugin/pull/64#discussion_r777745911, needed for https://github.com/jenkinsci/pipeline-input-step-plugin/pull/69.