### PR TITLE
[JENKINS-49707] Recommend `BodyExecution.cancel` overload taking `Throwable`

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/BodyExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/BodyExecution.java
@@ -77,7 +77,7 @@ public abstract class BodyExecution implements Future<Object>, Serializable {
      * If the body has finished executing, or is cancelled already, the attempt will
      * fail. This method is asynchronous. There's no guarantee that the cancellation
      * has happened or completed before this method returns.
-     *
+     * @param t reason for cancellation; typically a {@link FlowInterruptedException}
      * @return false if the task cannot be cancelled.
      */
     public boolean cancel(Throwable t) {

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/BodyExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/BodyExecution.java
@@ -56,7 +56,7 @@ public abstract class BodyExecution implements Future<Object>, Serializable {
     @Deprecated
     public boolean cancel(CauseOfInterruption... causes) {
         if (Util.isOverridden(BodyExecution.class, getClass(), "cancel", Throwable.class)) {
-            return cancel(new FlowInterruptedException(Result.ABORTED, causes));
+            return cancel(new FlowInterruptedException(Result.ABORTED, true, causes));
         } else {
             throw new AbstractMethodError("Override cancel(Throwable) from " + getClass());
         }

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/ExceptionCause.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/ExceptionCause.java
@@ -4,14 +4,7 @@ import jenkins.model.CauseOfInterruption;
 
 import java.io.Serializable;
 
-/**
- * {@link CauseOfInterruption} that captures random {@link Throwable},
- * which is used when the cancellation is in response to some failures.
- *
- * TODO: move this to core
- * TODO: better summary.jelly
- * @author Kohsuke Kawaguchi
- */
+@Deprecated
 class ExceptionCause extends CauseOfInterruption implements Serializable {
     private final Throwable t;
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/ExceptionCause.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/ExceptionCause.java
@@ -4,7 +4,14 @@ import jenkins.model.CauseOfInterruption;
 
 import java.io.Serializable;
 
-@Deprecated
+/**
+ * {@link CauseOfInterruption} that captures random {@link Throwable},
+ * which is used when the cancellation is in response to some failures.
+ *
+ * TODO: move this to core
+ * TODO: better summary.jelly
+ * @author Kohsuke Kawaguchi
+ */
 class ExceptionCause extends CauseOfInterruption implements Serializable {
     private final Throwable t;
 

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/FlowInterruptedException.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/FlowInterruptedException.java
@@ -67,14 +67,11 @@ public final class FlowInterruptedException extends InterruptedException {
     private Boolean actualInterruption = true;
 
     /**
-     * Creates a new exception.
-     * @param result the desired result for the flow, typically {@link Result#ABORTED}
-     * @param causes any indications
+     * @deprecated use {@link #FlowInterruptedException(Result, boolean, CauseOfInterruption...)}
      */
+    @Deprecated
     public FlowInterruptedException(@NonNull Result result, @NonNull CauseOfInterruption... causes) {
-        this.result = result;
-        this.causes = Arrays.asList(causes);
-        this.actualInterruption = true;
+        this(result, true, causes);
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/SynchronousStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/SynchronousStepExecution.java
@@ -51,6 +51,7 @@ public abstract class SynchronousStepExecution<T> extends StepExecution {
         Thread e = executing;   // capture
         if (e!=null) {
             if (e instanceof Executor) {
+                // TODO if cause instanceof FlowInterruptedException, unpack result & causes
                 ((Executor) e).interrupt(ABORTED, new ExceptionCause(cause));
             } else {
                 e.interrupt();


### PR DESCRIPTION
Follows up #51. Implemented in https://github.com/jenkinsci/workflow-cps-plugin/pull/570. https://github.com/jenkinsci/workflow-durable-task-step-plugin/pull/254 describes motivation.