### PR TITLE
Add Plugin Development Team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jenkinsci/workflow-step-api-plugin-developers


### PR DESCRIPTION
Hi!

This change adds a `CODEOWNERS` file ([docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners)) to ensure folks on the development team are notified about new contributions.

Newly generated plugins automatically get [this configuration](https://github.com/jenkinsci/archetypes/blob/master/common-files/.github/CODEOWNERS).


Use this link to re-run the recipe: https://app.moderne.io/recipes/org.openrewrite.jenkins.github.AddTeamToCodeowners