### PR TITLE
Mention step name in `MissingContextVariableException` detail message

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/MissingContextVariableException.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/MissingContextVariableException.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.workflow.steps;
 
+import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
 import java.util.List;
@@ -16,9 +17,17 @@ import java.util.Set;
  */
 public class MissingContextVariableException extends Exception {
     private final @NonNull Class<?> type;
+    private final @CheckForNull String functionName;
 
+    /** @deprecated use {@link #MissingContextVariableException(Class, StepDescriptor)} */
+    @Deprecated
     public MissingContextVariableException(@NonNull Class<?> type) {
+        this(type, null);
+    }
+
+    public MissingContextVariableException(@NonNull Class<?> type, @CheckForNull StepDescriptor d) {
         this.type = type;
+        functionName = d != null ? d.getFunctionName() : null;
     }
 
     public Class<?> getType() {
@@ -30,7 +39,11 @@ public class MissingContextVariableException extends Exception {
         boolean first = true;
         for (StepDescriptor p : getProviders()) {
             if (first) {
-                b.append("\nPerhaps you forgot to surround the code with a step that provides this, such as: ");
+                b.append("\nPerhaps you forgot to surround the ");
+                if (functionName != null) {
+                    b.append(functionName).append(" ");
+                }
+                b.append("step with a step that provides this, such as: ");
                 first = false;
             } else {
                 b.append(", ");

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/StepDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/StepDescriptor.java
@@ -261,8 +261,9 @@ public abstract class StepDescriptor extends Descriptor<Step> {
         // TODO the order here is nondeterministic; should we pick the lexicographic first? Or extend MissingContextVariableException to take a Set<Class<?>> types?
         for (Class<?> type : getRequiredContext()) {
             Object v = c.get(type);
-            if (v==null)
-                throw new MissingContextVariableException(type);
+            if (v == null) {
+                throw new MissingContextVariableException(type, this);
+            }
         }
     }
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/MissingContextVariableExceptionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/MissingContextVariableExceptionTest.java
@@ -1,0 +1,44 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2023 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.steps;
+
+import hudson.model.Result;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+public final class MissingContextVariableExceptionTest {
+
+    @Rule public JenkinsRule r = new JenkinsRule();
+
+    @Test public void message() throws Exception {
+        WorkflowJob p = r.createProject(WorkflowJob.class, "p");
+        p.setDefinition(new CpsFlowDefinition("sh 'oops'", true));
+        r.assertLogContains("Perhaps you forgot to surround the sh step with a step that provides this, such as: node", r.buildAndAssertStatus(Result.FAILURE, p));
+    }
+
+}


### PR DESCRIPTION
Otherwise depending on the stack trace it may not be obvious which step was being run. For compatibility, tolerate a missing `StepDescriptor` as in https://github.com/jenkinsci/workflow-basic-steps-plugin/blob/67fffaed1f2a764c36212ab6af3c26c0a04939dc/src/main/java/org/jenkinsci/plugins/workflow/steps/CoreStep.java#L90 or https://github.com/jenkinsci/credentials-binding-plugin/blob/fe78f71d97a6a3f293ed6e04c41706f7bb6686b0/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep.java#L130.