### PR TITLE
Forward compatibility with Guice 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,15 +64,15 @@
     <properties>
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-        <jenkins.version>2.387.3</jenkins.version>
+        <jenkins.version>2.414.3</jenkins.version>
         <no-test-jar>false</no-test-jar>
     </properties>
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.387.x</artifactId>
-                <version>2465.va_e76ed7b_3061</version>
+                <artifactId>bom-2.414.x</artifactId>
+                <version>2705.vf5c48c31285b_</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/AbstractStepDescriptorImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/AbstractStepDescriptorImpl.java
@@ -1,6 +1,6 @@
 package org.jenkinsci.plugins.workflow.steps;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Collections;

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/AbstractStepImpl.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/AbstractStepImpl.java
@@ -4,7 +4,7 @@ import com.google.inject.Injector;
 import jenkins.model.Jenkins;
 
 import edu.umd.cs.findbugs.annotations.Nullable;
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 /**
  * Partial convenient step implementation.

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/StepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/StepExecution.java
@@ -14,7 +14,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import jenkins.model.queue.AsynchronousExecution;
 import jenkins.util.Timer;
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/AbstractStepImplTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/AbstractStepImplTest.java
@@ -11,7 +11,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import java.util.HashMap;
 import java.util.Map;
 


### PR DESCRIPTION
Without dropping compatibility with Guice 6 (currently delivered by Jenkins core), add support for Guice 7.