### PR TITLE
Remove `@Nullable` annotation

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/StepContext.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/StepContext.java
@@ -76,7 +76,7 @@ public abstract class StepContext implements FutureCallback<Object>, Serializabl
      * @see BodyInvoker#withContext
      * @see DynamicContext
      */
-    public abstract @Nullable <T> T get(Class<T> key) throws IOException, InterruptedException;
+    public abstract <T> T get(Class<T> key) throws IOException, InterruptedException;
 
     @Override public abstract void onSuccess(@Nullable Object result);
 


### PR DESCRIPTION
Recent versions of `spotbugs-maven-plugin` no longer ignore `Nullable` and treat the presence of this annotation as a reason to log a new warning whenever anyone calls this method and doesn't check the result for null. Since our plugins do this in dozens of places this creates a lot of new warnings. This PR restores the old behavior by removing the `Nullable` annotation.

### Testing done

- `mvn clean verify -DskipTests`
- Reproduced the problem in `workflow-durable-task-step` plugin with SpotBugs 4.8.6.0; verified that after this PR most of the new warnings went away.