### PR TITLE
Add `SynchronousNonBlockingStepExecution.ExecutorServiceAugmentor` extension point

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/SynchronousNonBlockingStepExecution.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/SynchronousNonBlockingStepExecution.java
@@ -8,7 +8,6 @@ import hudson.util.ClassLoaderSanityThreadFactory;
 import hudson.util.DaemonThreadFactory;
 import hudson.util.NamingThreadFactory;
 
-import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -98,7 +97,7 @@ public abstract class SynchronousNonBlockingStepExecution<T> extends StepExecuti
         if (executorService == null) {
             ExecutorService result = Executors.newCachedThreadPool(new NamingThreadFactory(new ClassLoaderSanityThreadFactory(new DaemonThreadFactory()), "org.jenkinsci.plugins.workflow.steps.SynchronousNonBlockingStepExecution"));
             
-            for (SynchronousNonBlockingStepExecutorServiceAugmentor augmentor : ExtensionList.lookup(SynchronousNonBlockingStepExecutorServiceAugmentor.class)) {
+            for (ExecutorServiceAugmentor augmentor : ExtensionList.lookup(ExecutorServiceAugmentor.class)) {
                 result = augmentor.augment(result);
             }
             executorService = result;
@@ -110,9 +109,9 @@ public abstract class SynchronousNonBlockingStepExecution<T> extends StepExecuti
      * Extension point for augmenting the executorService of {@link SynchronousNonBlockingStepExecution}.
      */
     @Restricted(Beta.class)
-    public interface SynchronousNonBlockingStepExecutorServiceAugmentor extends ExtensionPoint {
+    public interface ExecutorServiceAugmentor extends ExtensionPoint {
         /**
-         * Augment the executor service used by {@link SynchronousNonBlockingStepExecution}.
+         * Augment the executor service used by {@link SynchronousNonBlockingStepExecution} and {@link GeneralNonBlockingStepExecution}.
          * @param executorService the executor service to augment
          */
         ExecutorService augment(ExecutorService executorService);

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/SynchronousNonBlockingStepExecutorServiceAugmentorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/SynchronousNonBlockingStepExecutorServiceAugmentorTest.java
@@ -1,11 +1,12 @@
 package org.jenkinsci.plugins.workflow.steps;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
 
 import java.util.concurrent.ExecutorService;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import org.hamcrest.Matchers;
+import org.junit.AfterClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -21,15 +22,40 @@ public class SynchronousNonBlockingStepExecutorServiceAugmentorTest {
     public LoggerRule loggerRule =
             new LoggerRule().record(AugmentorTestExtension.class, Level.FINE).capture(10);
 
+    /**
+     * As the JVM and classes are loaded only once for the whole test, {@link SynchronousNonBlockingStepExecution#getExecutorService()} augments only once. The current boolean keeps track of the augmentation status.
+     */
+    private static boolean augmented = false;
+
     @Test
-    public void smokes() throws Exception {
+    public void smokes_configured_once_A() throws Exception {
         SynchronousNonBlockingStepExecution.getExecutorService();
-        assertThat(loggerRule.getMessages(), hasItem("Augmenting"));
+        checkAugmentation();
+    }
+
+    @Test
+    public void smokes_configured_once_B() throws Exception {
+        SynchronousNonBlockingStepExecution.getExecutorService();
+        checkAugmentation();
+    }
+
+    private void checkAugmentation() {
+        if (augmented) {
+            assertThat(loggerRule.getMessages(), Matchers.emptyIterable());
+        } else {
+            assertThat(loggerRule.getMessages(), Matchers.hasItem("Augmenting"));
+            augmented = true;
+        }
+    }
+    
+    @AfterClass
+    public static void afterClass() {
+        // Reset the static state to ensure that the test can be run multiple times without issues.
+        assertThat(augmented, Matchers.is(true));
     }
 
     @TestExtension
-    public static class AugmentorTestExtension
-            implements SynchronousNonBlockingStepExecution.ExecutorServiceAugmentor {
+    public static class AugmentorTestExtension implements SynchronousNonBlockingStepExecution.ExecutorServiceAugmentor {
 
         private static final Logger LOGGER = Logger.getLogger(AugmentorTestExtension.class.getName());
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/SynchronousNonBlockingStepExecutorServiceAugmentorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/SynchronousNonBlockingStepExecutorServiceAugmentorTest.java
@@ -29,7 +29,7 @@ public class SynchronousNonBlockingStepExecutorServiceAugmentorTest {
 
     @TestExtension
     public static class AugmentorTestExtension
-            implements SynchronousNonBlockingStepExecution.SynchronousNonBlockingStepExecutorServiceAugmentor {
+            implements SynchronousNonBlockingStepExecution.ExecutorServiceAugmentor {
 
         private static final Logger LOGGER = Logger.getLogger(AugmentorTestExtension.class.getName());
 

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/SynchronousNonBlockingStepExecutorServiceAugmentorTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/SynchronousNonBlockingStepExecutorServiceAugmentorTest.java
@@ -1,0 +1,42 @@
+package org.jenkinsci.plugins.workflow.steps;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+
+import java.util.concurrent.ExecutorService;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.LoggerRule;
+import org.jvnet.hudson.test.TestExtension;
+
+public class SynchronousNonBlockingStepExecutorServiceAugmentorTest {
+
+    @Rule
+    public JenkinsRule r = new JenkinsRule();
+
+    @Rule
+    public LoggerRule loggerRule =
+            new LoggerRule().record(AugmentorTestExtension.class, Level.FINE).capture(10);
+
+    @Test
+    public void smokes() throws Exception {
+        SynchronousNonBlockingStepExecution.getExecutorService();
+        assertThat(loggerRule.getMessages(), hasItem("Augmenting"));
+    }
+
+    @TestExtension
+    public static class AugmentorTestExtension
+            implements SynchronousNonBlockingStepExecution.SynchronousNonBlockingStepExecutorServiceAugmentor {
+
+        private static final Logger LOGGER = Logger.getLogger(AugmentorTestExtension.class.getName());
+
+        @Override
+        public ExecutorService augment(ExecutorService executorService) {
+            LOGGER.fine(() -> "Augmenting");
+            return executorService;
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Allow the `executorService` to be augmented.
This avoids having to use reflection by dependent plugins.

See https://github.com/jenkinsci/opentelemetry-plugin/pull/1139 for the consumer.

Updated with [comment](https://github.com/jenkinsci/workflow-step-api-plugin/pull/226#issuecomment-3024992806) from @dwnusbaum 
> 
> `opentelemetry` wants to make it possible for other plugins to augment the traces produced for Jenkins builds. See [jenkinsci/opentelemetry-plugin#896](https://github.com/jenkinsci/opentelemetry-plugin/pull/896) and [jenkinsci/opentelemetry-plugin#909](https://github.com/jenkinsci/opentelemetry-plugin/pull/909) for more context. See [jenkinsci/junit-sql-storage-plugin#413](https://github.com/jenkinsci/junit-sql-storage-plugin/pull/413) for an example of a plugin using the OTel context to emit custom spans as part of the `junit` step.
> 
> In order for this to work, plugins need access to an OTel `Context` in their build steps and/or related code so that they can produce a `Span` with the correct parent. By default, OTel contexts are stored as a `ThreadLocal` variable. `opentelemetry`'s synchronous `GraphListener` implementation sets up this context on the CPS VM thread when a new step starts. For Pipeline steps with fully synchronous `StepExecution`s, that is enough for context propagation to work correctly within the extent of `StepExecution.start`. However, for steps whose execution runs on another thread, even if they complete synchronously from the perspective of the Pipeline (e.g. `SynchronousNonBlockingStepExecution`, `GeneralNonBlockingStepExecution`), the context will be unavailable, and so any created OTel span will not have the correct parent.
> 
> `opentelemetry` plugin currently handles this case by [reflectively modifying `SynchronousNonBlockingStepExecution.executorService`](https://github.com/jenkinsci/opentelemetry-plugin/blob/18f89dda0128c15637bc9086cca6b6387d47d65a/src/main/java/io/jenkins/plugins/opentelemetry/init/StepExecutionInstrumentationInitializer.java#L34-L41) to wrap it with [`io.opentelemetry.context.Context.taskWrapping`](https://github.com/open-telemetry/opentelemetry-java/blob/43f3f7d059ecfcecf7688f141eaa4690f8b20386/context/src/main/java/io/opentelemetry/context/Context.java#L138-L143), which automatically propagates the thread local OTel context to tasks run on the executor service. This works, but this kind of reflection is brittle, and we would like to support this use case in a more maintainable way. This PR currently just exposes a `@Restricted(Beta.class)` API to allow `opentelemetry` to augment `SynchronousNonBlockingStepExecution.executorService` with `Context.taskWrapping` without using reflection.
> 
> There may be other ways to accomplish the same use case, but we have not explored them at this time: For example:
> 
> * Perhaps we should instead encourage plugins with build steps that want to support tracing to always look up their parent span using [these methods](https://github.com/jenkinsci/opentelemetry-plugin/blob/18f89dda0128c15637bc9086cca6b6387d47d65a/src/main/java/io/jenkins/plugins/opentelemetry/job/OtelTraceService.java#L78-L110) and then set up the context manually as needed? For `junit-sql-storage` this would mean that the `junit` step would need to be updated to look up the span and then set up the thread local context for methods in the custom storage provider.
> * Similarly, could we somehow inject the OTel `Context` into the `StepContext` for each step automatically, and then have some kind of method like `OtelPlugin.useContext(StepContext)` that sets up the thread local for plugins that need it? This would only work for Pipeline `Step`s, but maybe that's ok?
> * There is a [`ContextStorageProvider`](https://github.com/open-telemetry/opentelemetry-java/blob/43f3f7d059ecfcecf7688f141eaa4690f8b20386/context/src/main/java/io/opentelemetry/context/ContextStorageProvider.java) API. Perhaps we could implement this in a way that works better for our use case?
> EDIT: Or perhaps we could invert the dependency as described in: https://github.com/jenkinsci/workflow-step-api-plugin/pull/226#issuecomment-3032799853




### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
