### PR TITLE
FlowInterruptedException::getMessage returns exception details

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target
 work
 *.iml
+.idea

--- a/src/main/java/org/jenkinsci/plugins/workflow/steps/FlowInterruptedException.java
+++ b/src/main/java/org/jenkinsci/plugins/workflow/steps/FlowInterruptedException.java
@@ -36,6 +36,8 @@ import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
+
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import jenkins.model.CauseOfInterruption;
@@ -107,6 +109,13 @@ public final class FlowInterruptedException extends InterruptedException {
             actualInterruption = true;
         }
         return this;
+    }
+
+    @Override
+    public String getMessage() {
+        return causes.stream()
+            .map(CauseOfInterruption::getShortDescription)
+            .collect(Collectors.joining( ", " ));
     }
 
     /**

--- a/src/test/java/org/jenkinsci/plugins/workflow/steps/FlowInterruptedExceptionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/workflow/steps/FlowInterruptedExceptionTest.java
@@ -1,0 +1,74 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2025 Damian Szczepanik
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.workflow.steps;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+import hudson.model.Result;
+import hudson.model.Run;
+import jenkins.model.CauseOfInterruption;
+import org.jenkinsci.plugins.workflow.job.properties.DisableConcurrentBuildsJobProperty;
+import org.junit.Assert;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+/**
+ * Tests some specific {@link FlowInterruptedException} APIs
+ */
+public class FlowInterruptedExceptionTest {
+
+    @Test
+    public void getMessageReturnsCauses() {
+        // given
+        Result result = Result.ABORTED;
+        CauseOfInterruption cause1 = new ExceptionCause(new IllegalStateException("something went wrong"));
+        CauseOfInterruption cause2 = new CauseOfInterruption.UserInterruption("admin");
+        CauseOfInterruption[] causes = {cause1, cause2};
+
+        // when
+        FlowInterruptedException exception = new FlowInterruptedException(result, true, causes);
+
+        // then
+        assertThat(exception.getMessage(), equalTo(cause1.getShortDescription() + ", " + cause2.getShortDescription()));
+    }
+
+    @Test
+    public void toStringContainsCauses() {
+        // given
+        Result result = Result.FAILURE;
+        Run run = Mockito.mock(Run.class);
+        Mockito.when(run.getDisplayName()).thenReturn("fracture.account");
+        CauseOfInterruption cause = new DisableConcurrentBuildsJobProperty.CancelledCause(run);
+
+        // when
+        FlowInterruptedException exception = new FlowInterruptedException(result, true, cause);
+
+        // then
+        assertThat(exception.toString(), containsString(cause.getShortDescription()));
+    }
+}


### PR DESCRIPTION
Class `FlowInterruptedException` does not meet `getMessage()` contract defined in [Throwable](https://docs.oracle.com/javase/8/docs/api/java/lang/Throwable.html#getMessage--) class.

Constructor does not pass `message` to parent class so later `getMessage()` returns `null` value. This means that every generic code that uses `getMessage()` in `try catch` block returns empty value for this class making debugging harder.

### Testing done

Unit test cases have been provided to prove the implementation.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
